### PR TITLE
Add simulate command in PerformanceCalculator simulating performance

### DIFF
--- a/PerformanceCalculator/Program.cs
+++ b/PerformanceCalculator/Program.cs
@@ -6,12 +6,14 @@ using osu.Framework.Logging;
 using osu.Game.Beatmaps.Formats;
 using PerformanceCalculator.Difficulty;
 using PerformanceCalculator.Performance;
+using PerformanceCalculator.Simulate;
 
 namespace PerformanceCalculator
 {
     [Command("dotnet PerformanceCalculator.dll")]
     [Subcommand("difficulty", typeof(DifficultyCommand))]
     [Subcommand("performance", typeof(PerformanceCommand))]
+    [Subcommand("simulate", typeof(SimulateCommand))]
     public class Program : CommandBase
     {
         public static void Main(string[] args)

--- a/PerformanceCalculator/README.md
+++ b/PerformanceCalculator/README.md
@@ -106,11 +106,11 @@ Run 'simulate [command] --help' for more information about a command.
 Computes the performance of a simulated play on a beatmap. The provided output includes raw performance attributes and pp value.
 
 
-#### Osu
+#### osu!
 ```
 > dotnet PerformanceCalculator.dll simulate osu --help
 
-Computes the performance (pp) of a simulated osu play.
+Computes the performance (pp) of a simulated osu! play.
 
 Usage: dotnet PerformanceCalculator.dll simulate osu [arguments] [options]
 
@@ -126,11 +126,11 @@ Options:
   -M|--misses <misses>        Number of misses. Defaults to 0.
 ```
 
-#### Taiko
+#### osu!taiko
 ```
 > dotnet PerformanceCalculator.dll simulate taiko --help
 
-Computes the performance (pp) of a simulated taiko play.
+Computes the performance (pp) of a simulated osu!taiko play.
 
 Usage: dotnet PerformanceCalculator.dll simulate taiko [arguments] [options]
 
@@ -146,11 +146,11 @@ Options:
   -M|--misses <misses>        Number of misses. Defaults to 0.
 ```
 
-#### Mania
+#### osu!mania
 ```
 > dotnet PerformanceCalculator.dll simulate mania --help
 
-Computes the performance (pp) of a simulated mania play.
+Computes the performance (pp) of a simulated osu!mania play.
 
 Usage: dotnet PerformanceCalculator.dll simulate mania [arguments] [options]
 

--- a/PerformanceCalculator/README.md
+++ b/PerformanceCalculator/README.md
@@ -119,11 +119,13 @@ Arguments:
 
 Options:
   -?|-h|--help                Show help information
-  -a|--accuracy <accuracy>    Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well.
+  -a|--accuracy <accuracy>    Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well and is rounded to the nearest possible value for the beatmap.
   -c|--combo <combo>          Maximum combo during play. Defaults to beatmap maximum.
   -C|--percent-combo <combo>  Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.
   -m|--mod <mod>              One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, ez, etc...
-  -M|--misses <misses>        Number of misses. Defaults to 0.
+  -X|--misses <misses>        Number of misses. Defaults to 0.
+  -M|--mehs <mehs>            Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.
+  -G|--goods <goods>          Number of goods. Will override accuracy if used. Otherwise is automatically calculated.
 ```
 
 #### osu!taiko
@@ -139,11 +141,12 @@ Arguments:
 
 Options:
   -?|-h|--help                Show help information
-  -a|--accuracy <accuracy>    Accuracy. Enter as decimal 0-100. Defaults to 100.
+  -a|--accuracy <accuracy>    Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well and is rounded to the nearest possible value for the beatmap.
   -c|--combo <combo>          Maximum combo during play. Defaults to beatmap maximum.
   -C|--percent-combo <combo>  Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.
   -m|--mod <mod>              One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, ez, etc...
-  -M|--misses <misses>        Number of misses. Defaults to 0.
+  -X|--misses <misses>        Number of misses. Defaults to 0.
+  -G|--goods <goods>          Number of goods. Will override accuracy if used. Otherwise is automatically calculated.
 ```
 
 #### osu!mania

--- a/PerformanceCalculator/README.md
+++ b/PerformanceCalculator/README.md
@@ -27,6 +27,7 @@ Options:
 Commands:
   difficulty    Computes the difficulty of a beatmap.
   performance   Computes the performance (pp) of replays on a beatmap.
+  simulate      Computes the performance (pp) of a simulated play.
 
 Run 'dotnet PerformanceCalculator.dll [command] --help' for more information about a command.
 ```
@@ -81,4 +82,83 @@ Aim            : 123.614719845539
 Speed          : 44.7315288123673
 Accuracy       : 61.9354071284508
 pp             : 235.580094436267
+```
+
+### Simulate
+```
+> dotnet PerformanceCalculator.dll simulate
+
+Computes the performance (pp) of a simulated play.
+
+Usage: dotnet PerformanceCalculator.dll simulate [options] [command]
+
+Options:
+  -?|-h|--help  Show help information
+
+Commands:
+  mania         Computes the performance (pp) of a simulated mania play.
+  osu           Computes the performance (pp) of a simulated osu play.
+  taiko         Computes the performance (pp) of a simulated taiko play.
+
+Run 'simulate [command] --help' for more information about a command.
+
+```
+Computes the performance of a simulated play on a beatmap. The provided output includes raw performance attributes and pp value.
+
+
+#### Osu
+```
+> dotnet PerformanceCalculator.dll simulate osu --help
+
+Computes the performance (pp) of a simulated osu play.
+
+Usage: dotnet PerformanceCalculator.dll simulate osu [arguments] [options]
+
+Arguments:
+  beatmap                     Required. The beatmap file (.osu).
+
+Options:
+  -?|-h|--help                Show help information
+  -a|--accuracy <accuracy>    Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well.
+  -c|--combo <combo>          Maximum combo during play. Defaults to beatmap maximum.
+  -C|--percent-combo <combo>  Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.
+  -m|--mod <mod>              One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, ez, etc...
+  -M|--misses <misses>        Number of misses. Defaults to 0.
+```
+
+#### Taiko
+```
+> dotnet PerformanceCalculator.dll simulate taiko --help
+
+Computes the performance (pp) of a simulated taiko play.
+
+Usage: dotnet PerformanceCalculator.dll simulate taiko [arguments] [options]
+
+Arguments:
+  beatmap                     Required. The beatmap file (.osu).
+
+Options:
+  -?|-h|--help                Show help information
+  -a|--accuracy <accuracy>    Accuracy. Enter as decimal 0-100. Defaults to 100.
+  -c|--combo <combo>          Maximum combo during play. Defaults to beatmap maximum.
+  -C|--percent-combo <combo>  Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.
+  -m|--mod <mod>              One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, ez, etc...
+  -M|--misses <misses>        Number of misses. Defaults to 0.
+```
+
+#### Mania
+```
+> dotnet PerformanceCalculator.dll simulate mania --help
+
+Computes the performance (pp) of a simulated mania play.
+
+Usage: dotnet PerformanceCalculator.dll simulate mania [arguments] [options]
+
+Arguments:
+  beatmap             Required. The beatmap file (.osu).
+
+Options:
+  -?|-h|--help        Show help information
+  -s|--score <score>  Score. An integer 0-1000000.
+  -m|--mod <mod>      One for each mod. The mods to compute the performance with. Values: hr, dt, fl, 4k, 5k, etc...
 ```

--- a/PerformanceCalculator/Simulate/BaseSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/BaseSimulateCommand.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
+
+using JetBrains.Annotations;
+using osu.Game.Rulesets;
+
+namespace PerformanceCalculator.Simulate
+{
+    public abstract class BaseSimulateCommand : ProcessorCommand
+    {
+        public abstract string Beatmap { get; }
+
+        public abstract Ruleset Ruleset { get;  }
+
+        [UsedImplicitly]
+        public virtual double Accuracy { get; }
+
+        [UsedImplicitly]
+        public virtual int? Combo { get; }
+
+        [UsedImplicitly]
+        public virtual double PercentCombo { get; }
+
+        [UsedImplicitly]
+        public virtual int Score { get; }
+
+        [UsedImplicitly]
+        public virtual string[] Mods { get; }
+
+        [UsedImplicitly]
+        public virtual int Misses { get; }
+    }
+}

--- a/PerformanceCalculator/Simulate/BaseSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/BaseSimulateCommand.cs
@@ -29,5 +29,11 @@ namespace PerformanceCalculator.Simulate
 
         [UsedImplicitly]
         public virtual int Misses { get; }
+
+        [UsedImplicitly]
+        public virtual int? Mehs { get; }
+
+        [UsedImplicitly]
+        public virtual int? Goods { get; }
     }
 }

--- a/PerformanceCalculator/Simulate/BaseSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/BaseSimulateProcessor.cs
@@ -1,0 +1,95 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace PerformanceCalculator.Simulate
+{
+    public abstract class BaseSimulateProcessor : IProcessor
+    {
+        private readonly BaseSimulateCommand command;
+
+        protected BaseSimulateProcessor(BaseSimulateCommand command)
+        {
+            this.command = command;
+        }
+
+        public void Execute()
+        {
+            var ruleset = command.Ruleset;
+
+            var mods = getMods(ruleset).ToArray();
+
+            var workingBeatmap = new ProcessorWorkingBeatmap(command.Beatmap);
+            workingBeatmap.Mods.Value = mods;
+
+            var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
+
+            var accuracy = command.Accuracy / 100;
+            var beatmapMaxCombo = GetMaxCombo(beatmap);
+            var maxCombo = command.Combo ?? (int)Math.Round(command.PercentCombo / 100 * beatmapMaxCombo);
+            var statistics = GenerateHitResults(accuracy, beatmap, command.Misses);
+            var score = command.Score;
+
+            var scoreInfo = new ScoreInfo
+            {
+                Accuracy = accuracy,
+                MaxCombo = maxCombo,
+                Statistics = statistics,
+                Mods = mods,
+                TotalScore = score
+            };
+
+            var categoryAttribs = new Dictionary<string, double>();
+            double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
+
+            command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
+
+            WritePlayInfo(scoreInfo, beatmap);
+
+            WriteAttribute("Mods", mods.Length > 0
+                ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")
+                : "None");
+
+            foreach (var kvp in categoryAttribs)
+                WriteAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
+
+            WriteAttribute("pp", pp.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private List<Mod> getMods(Ruleset ruleset)
+        {
+            var mods = new List<Mod>();
+            if (command.Mods == null)
+                return mods;
+
+            var availableMods = ruleset.GetAllMods().ToList();
+            foreach (var modString in command.Mods)
+            {
+                Mod newMod = availableMods.FirstOrDefault(m => string.Equals(m.Acronym, modString, StringComparison.CurrentCultureIgnoreCase));
+                if (newMod == null)
+                    throw new ArgumentException($"Invalid mod provided: {modString}");
+                mods.Add(newMod);
+            }
+
+            return mods;
+        }
+
+        protected abstract void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap);
+
+        protected abstract int GetMaxCombo(IBeatmap beatmap);
+
+        protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int amountMiss);
+
+        protected void WriteAttribute(string name, string value) => command.Console.WriteLine($"{name.PadRight(15)}: {value}");
+    }
+}

--- a/PerformanceCalculator/Simulate/BaseSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/BaseSimulateProcessor.cs
@@ -34,11 +34,11 @@ namespace PerformanceCalculator.Simulate
 
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
 
-            var accuracy = command.Accuracy / 100;
             var beatmapMaxCombo = GetMaxCombo(beatmap);
             var maxCombo = command.Combo ?? (int)Math.Round(command.PercentCombo / 100 * beatmapMaxCombo);
-            var statistics = GenerateHitResults(accuracy, beatmap, command.Misses);
+            var statistics = GenerateHitResults(command.Accuracy / 100, beatmap, command.Misses, command.Mehs, command.Goods);
             var score = command.Score;
+            var accuracy = GetAccuracy(statistics);
 
             var scoreInfo = new ScoreInfo
             {
@@ -88,7 +88,9 @@ namespace PerformanceCalculator.Simulate
 
         protected abstract int GetMaxCombo(IBeatmap beatmap);
 
-        protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int amountMiss);
+        protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood);
+
+        protected virtual double GetAccuracy(Dictionary<HitResult, int> statistics) => 0;
 
         protected void WriteAttribute(string name, string value) => command.Console.WriteLine($"{name.PadRight(15)}: {value}");
     }

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateCommand.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
+
+using System.ComponentModel.DataAnnotations;
+using JetBrains.Annotations;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace PerformanceCalculator.Simulate.Mania
+{
+    [Command(Name = "simulate mania", Description = "Computes the performance (pp) of a simulated mania play.")]
+    public class ManiaSimulateCommand : ProcessorCommand
+    {
+        [UsedImplicitly]
+        [Required, FileExists]
+        [Argument(0, Name = "beatmap", Description = "Required. The beatmap file (.osu).")]
+        public string Beatmap { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-s|--score <score>", Description = "Score. An integer 0-1000000.")]
+        public int Score { get; }
+
+        [UsedImplicitly]
+        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
+                                                                                            + "Values: hr, dt, fl, 4k, 5k, etc...")]
+        public string[] Mods { get; }
+
+        protected override IProcessor CreateProcessor() => new ManiaSimulateProcessor(this);
+    }
+}

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateCommand.cs
@@ -7,7 +7,7 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace PerformanceCalculator.Simulate.Mania
 {
-    [Command(Name = "simulate mania", Description = "Computes the performance (pp) of a simulated mania play.")]
+    [Command(Name = "simulate mania", Description = "Computes the performance (pp) of a simulated osu!mania play.")]
     public class ManiaSimulateCommand : ProcessorCommand
     {
         [UsedImplicitly]

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateCommand.cs
@@ -4,25 +4,29 @@
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mania;
 
 namespace PerformanceCalculator.Simulate.Mania
 {
     [Command(Name = "simulate mania", Description = "Computes the performance (pp) of a simulated osu!mania play.")]
-    public class ManiaSimulateCommand : ProcessorCommand
+    public class ManiaSimulateCommand : BaseSimulateCommand
     {
         [UsedImplicitly]
         [Required, FileExists]
         [Argument(0, Name = "beatmap", Description = "Required. The beatmap file (.osu).")]
-        public string Beatmap { get; }
+        public override string Beatmap { get; }
 
         [UsedImplicitly]
         [Option(Template = "-s|--score <score>", Description = "Score. An integer 0-1000000.")]
-        public int Score { get; }
+        public override int Score { get; } = 1000000;
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
                                                                                             + " Values: hr, dt, fl, 4k, 5k, etc...")]
-        public string[] Mods { get; }
+        public override string[] Mods { get; }
+
+        public override Ruleset Ruleset => new ManiaRuleset();
 
         protected override IProcessor CreateProcessor() => new ManiaSimulateProcessor(this);
     }

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateCommand.cs
@@ -21,7 +21,7 @@ namespace PerformanceCalculator.Simulate.Mania
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                            + "Values: hr, dt, fl, 4k, 5k, etc...")]
+                                                                                            + " Values: hr, dt, fl, 4k, 5k, etc...")]
         public string[] Mods { get; }
 
         protected override IProcessor CreateProcessor() => new ManiaSimulateProcessor(this);

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
@@ -13,7 +13,7 @@ namespace PerformanceCalculator.Simulate.Mania
     {
         protected override int GetMaxCombo(IBeatmap beatmap) => 0;
 
-        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int amountMiss)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
         {
             var totalHits = beatmap.HitObjects.Count;
 

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
@@ -87,12 +87,12 @@ namespace PerformanceCalculator.Simulate.Mania
             // Only total number of hits is considered currently, so specifics don't matter
             return new Dictionary<HitResult, int>
             {
-                {HitResult.Perfect, totalHits},
-                {HitResult.Great, 0},
-                {HitResult.Ok, 0},
-                {HitResult.Good, 0},
-                {HitResult.Meh, 0},
-                {HitResult.Miss, 0}
+                { HitResult.Perfect, totalHits },
+                { HitResult.Great, 0 },
+                { HitResult.Ok, 0 },
+                { HitResult.Good, 0 },
+                { HitResult.Meh, 0 },
+                { HitResult.Miss, 0 }
             };
         }
 

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
@@ -38,7 +38,7 @@ namespace PerformanceCalculator.Simulate.Mania
             var score = command.Score;
             var statistics = generateHitResults(beatmap);
 
-            var scoreInfo = new ScoreInfo()
+            var scoreInfo = new ScoreInfo
             {
                 TotalScore = score,
                 Statistics = statistics,
@@ -82,10 +82,10 @@ namespace PerformanceCalculator.Simulate.Mania
 
         private Dictionary<HitResult, int> generateHitResults(IBeatmap beatmap)
         {
-            var totalHits = beatmap.HitObjects.Count();
+            var totalHits = beatmap.HitObjects.Count;
 
             // Only total number of hits is considered currently, so specifics don't matter
-            return new Dictionary<HitResult, int>()
+            return new Dictionary<HitResult, int>
             {
                 {HitResult.Perfect, totalHits},
                 {HitResult.Great, 0},

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace PerformanceCalculator.Simulate.Mania
+{
+    public class ManiaSimulateProcessor : IProcessor
+    {
+        private readonly ManiaSimulateCommand command;
+
+        public ManiaSimulateProcessor(ManiaSimulateCommand command)
+        {
+            this.command = command;
+        }
+
+        public void Execute()
+        {
+            var ruleset = new ManiaRuleset();
+
+            var mods = getMods(ruleset).ToArray();
+
+            var workingBeatmap = new ProcessorWorkingBeatmap(command.Beatmap);
+            workingBeatmap.Mods.Value = mods;
+
+            var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
+
+            var score = command.Score;
+            var statistics = generateHitResults(beatmap);
+
+            var scoreInfo = new ScoreInfo()
+            {
+                TotalScore = score,
+                Statistics = statistics,
+                Mods = mods
+
+            };
+
+            var categoryAttribs = new Dictionary<string, double>();
+            double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
+
+            command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
+
+            writeAttribute("Score", score.ToString(CultureInfo.InvariantCulture));
+
+            writeAttribute("Mods", mods.Length > 0
+                ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")
+                : "None");
+
+            foreach (var kvp in categoryAttribs)
+                writeAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
+
+            writeAttribute("pp", pp.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private List<Mod> getMods(Ruleset ruleset)
+        {
+            var mods = new List<Mod>();
+            if (command.Mods == null)
+                return mods;
+
+            var availableMods = ruleset.GetAllMods().ToList();
+            foreach (var modString in command.Mods)
+            {
+                Mod newMod = availableMods.FirstOrDefault(m => string.Equals(m.Acronym, modString, StringComparison.CurrentCultureIgnoreCase));
+                if (newMod == null)
+                    throw new ArgumentException($"Invalid mod provided: {modString}");
+                mods.Add(newMod);
+            }
+
+            return mods;
+        }
+
+        private Dictionary<HitResult, int> generateHitResults(IBeatmap beatmap)
+        {
+            var totalHits = beatmap.HitObjects.Count();
+
+            // Only total number of hits is considered currently, so specifics don't matter
+            return new Dictionary<HitResult, int>()
+            {
+                {HitResult.Perfect, totalHits},
+                {HitResult.Great, 0},
+                {HitResult.Ok, 0},
+                {HitResult.Good, 0},
+                {HitResult.Meh, 0},
+                {HitResult.Miss, 0}
+            };
+        }
+
+        private void writeAttribute(string name, string value) => command.Console.WriteLine($"{name.PadRight(15)}: {value}");
+    }
+}

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
@@ -43,7 +43,6 @@ namespace PerformanceCalculator.Simulate.Mania
                 TotalScore = score,
                 Statistics = statistics,
                 Mods = mods
-
             };
 
             var categoryAttribs = new Dictionary<string, double>();

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
@@ -1,5 +1,5 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
 
 using System;
 using System.Collections.Generic;

--- a/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Mania/ManiaSimulateProcessor.cs
@@ -1,86 +1,19 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
 
-using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Linq;
-using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mania;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
 namespace PerformanceCalculator.Simulate.Mania
 {
-    public class ManiaSimulateProcessor : IProcessor
+    public class ManiaSimulateProcessor : BaseSimulateProcessor
     {
-        private readonly ManiaSimulateCommand command;
+        protected override int GetMaxCombo(IBeatmap beatmap) => 0;
 
-        public ManiaSimulateProcessor(ManiaSimulateCommand command)
-        {
-            this.command = command;
-        }
-
-        public void Execute()
-        {
-            var ruleset = new ManiaRuleset();
-
-            var mods = getMods(ruleset).ToArray();
-
-            var workingBeatmap = new ProcessorWorkingBeatmap(command.Beatmap);
-            workingBeatmap.Mods.Value = mods;
-
-            var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
-
-            var score = command.Score;
-            var statistics = generateHitResults(beatmap);
-
-            var scoreInfo = new ScoreInfo
-            {
-                TotalScore = score,
-                Statistics = statistics,
-                Mods = mods
-            };
-
-            var categoryAttribs = new Dictionary<string, double>();
-            double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
-
-            command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
-
-            writeAttribute("Score", score.ToString(CultureInfo.InvariantCulture));
-
-            writeAttribute("Mods", mods.Length > 0
-                ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")
-                : "None");
-
-            foreach (var kvp in categoryAttribs)
-                writeAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
-
-            writeAttribute("pp", pp.ToString(CultureInfo.InvariantCulture));
-        }
-
-        private List<Mod> getMods(Ruleset ruleset)
-        {
-            var mods = new List<Mod>();
-            if (command.Mods == null)
-                return mods;
-
-            var availableMods = ruleset.GetAllMods().ToList();
-            foreach (var modString in command.Mods)
-            {
-                Mod newMod = availableMods.FirstOrDefault(m => string.Equals(m.Acronym, modString, StringComparison.CurrentCultureIgnoreCase));
-                if (newMod == null)
-                    throw new ArgumentException($"Invalid mod provided: {modString}");
-                mods.Add(newMod);
-            }
-
-            return mods;
-        }
-
-        private Dictionary<HitResult, int> generateHitResults(IBeatmap beatmap)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int amountMiss)
         {
             var totalHits = beatmap.HitObjects.Count;
 
@@ -96,6 +29,14 @@ namespace PerformanceCalculator.Simulate.Mania
             };
         }
 
-        private void writeAttribute(string name, string value) => command.Console.WriteLine($"{name.PadRight(15)}: {value}");
+        protected override void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
+        {
+            WriteAttribute("Score", scoreInfo.TotalScore.ToString(CultureInfo.InvariantCulture));
+        }
+
+        public ManiaSimulateProcessor(BaseSimulateCommand command)
+            : base(command)
+        {
+        }
     }
 }

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
@@ -30,7 +30,7 @@ namespace PerformanceCalculator.Simulate.Osu
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                            + "Values: hr, dt, hd, fl, ez, etc...")]
+                                                                                            + " Values: hr, dt, hd, fl, ez, etc...")]
         public string[] Mods { get; }
 
         [UsedImplicitly]

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
+
+using System.ComponentModel.DataAnnotations;
+using JetBrains.Annotations;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace PerformanceCalculator.Simulate.Osu
+{
+    [Command(Name = "performance", Description = "Computes the performance (pp) of a simulated osu play.")]
+    public class OsuSimulateCommand : ProcessorCommand
+    {
+        [UsedImplicitly]
+        [Required, FileExists]
+        [Argument(0, Name = "beatmap", Description = "Required. The beatmap file (.osu).")]
+        public string Beatmap { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales number of 300s and 100s as well.")]
+        public double? Accuracy { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-c|--combo|--max-combo <combo>", Description = "Max Combo. Enter as integer. Defaults to beatmap maximum.")]
+        public int? MaxCombo { get; }
+
+        [UsedImplicitly]
+        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
+                                                                                            + "Values: hr, dt, hd, fl, ez, etc...")]
+        public string[] Mods { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-M|--misses <misses>", Description = "Number of misses. Defaults to 0. Enter as integer.")]
+        public int? Misses { get; }
+
+        protected override IProcessor CreateProcessor() => new OsuSimulateProcessor(this);
+    }
+}

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
@@ -4,38 +4,42 @@
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Osu;
 
 namespace PerformanceCalculator.Simulate.Osu
 {
     [Command(Name = "simulate osu", Description = "Computes the performance (pp) of a simulated osu! play.")]
-    public class OsuSimulateCommand : ProcessorCommand
+    public class OsuSimulateCommand : BaseSimulateCommand
     {
         [UsedImplicitly]
         [Required, FileExists]
         [Argument(0, Name = "beatmap", Description = "Required. The beatmap file (.osu).")]
-        public string Beatmap { get; }
+        public override string Beatmap { get; }
 
         [UsedImplicitly]
         [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well.")]
-        public double? Accuracy { get; }
+        public override double Accuracy { get; } = 100;
 
         [UsedImplicitly]
         [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]
-        public int? Combo { get; }
+        public override int? Combo { get; }
 
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
                                                                        + " Enter as decimal 0-100.")]
-        public double? PercentCombo { get; }
+        public override double PercentCombo { get; } = 100;
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
                                                                                             + " Values: hr, dt, hd, fl, ez, etc...")]
-        public string[] Mods { get; }
+        public override string[] Mods { get; }
 
         [UsedImplicitly]
         [Option(Template = "-M|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
-        public int? Misses { get; }
+        public override int Misses { get; }
+
+        public override Ruleset Ruleset => new OsuRuleset();
 
         protected override IProcessor CreateProcessor() => new OsuSimulateProcessor(this);
     }

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
@@ -20,8 +20,13 @@ namespace PerformanceCalculator.Simulate.Osu
         public double? Accuracy { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-c|--combo|--max-combo <combo>", Description = "Maximum Combo. Defaults to beatmap maximum.")]
-        public int? MaxCombo { get; }
+        [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]
+        public int? Combo { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
+                                                                       + " Enter as decimal 0-100.")]
+        public double? PercentCombo { get; }
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
@@ -18,7 +18,8 @@ namespace PerformanceCalculator.Simulate.Osu
         public override string Beatmap { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well.")]
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
+                                                                     + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
         public override double Accuracy { get; } = 100;
 
         [UsedImplicitly]
@@ -36,8 +37,16 @@ namespace PerformanceCalculator.Simulate.Osu
         public override string[] Mods { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-M|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
+        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
         public override int Misses { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-M|--mehs <mehs>", Description = "Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Mehs { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Goods { get; }
 
         public override Ruleset Ruleset => new OsuRuleset();
 

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateCommand.cs
@@ -7,7 +7,7 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace PerformanceCalculator.Simulate.Osu
 {
-    [Command(Name = "simulate osu", Description = "Computes the performance (pp) of a simulated osu play.")]
+    [Command(Name = "simulate osu", Description = "Computes the performance (pp) of a simulated osu! play.")]
     public class OsuSimulateCommand : ProcessorCommand
     {
         [UsedImplicitly]

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
@@ -42,7 +42,7 @@ namespace PerformanceCalculator.Simulate.Osu
                            (int) Math.Round((command.PercentCombo ?? 100)/100 * beatmapMaxCombo);
             var statistics = generateHitResults(accuracy, beatmap, command.Misses ?? 0);
 
-            var scoreInfo = new ScoreInfo()
+            var scoreInfo = new ScoreInfo
             {
                 Accuracy = accuracy,
                 MaxCombo = maxCombo,
@@ -89,7 +89,7 @@ namespace PerformanceCalculator.Simulate.Osu
 
         private Dictionary<HitResult, int> generateHitResults(double accuracy, IBeatmap beatmap, int amountMiss)
         {
-            var totalHitObjects = beatmap.HitObjects.Count();
+            var totalHitObjects = beatmap.HitObjects.Count;
 
             // Let Great=6, Good=2, Meh=1, Miss=0. The total should be this.
             var targetTotal = (int) Math.Round(accuracy*totalHitObjects*6);
@@ -105,7 +105,7 @@ namespace PerformanceCalculator.Simulate.Osu
             // Mehs are left over. Could be negative if impossible value of amountMiss chosen
             var amountMeh = totalHitObjects - amountGreat - amountGood - amountMiss;
 
-            return new Dictionary<HitResult, int>()
+            return new Dictionary<HitResult, int>
             {
                 {HitResult.Great, amountGreat},
                 {HitResult.Good, amountGood},

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
@@ -14,13 +14,13 @@ using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
-namespace PerformanceCalculator.Simulate
+namespace PerformanceCalculator.Simulate.Osu
 {
-    public class SimulateProcessor : IProcessor
+    public class OsuSimulateProcessor : IProcessor
     {
-        private readonly SimulateCommand command;
+        private readonly OsuSimulateCommand command;
 
-        public SimulateProcessor(SimulateCommand command)
+        public OsuSimulateProcessor(OsuSimulateCommand command)
         {
             this.command = command;
         }

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
@@ -37,7 +37,9 @@ namespace PerformanceCalculator.Simulate.Osu
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
 
             var accuracy = command.Accuracy/100 ?? 1.0;
-            var maxCombo = command.MaxCombo ?? (beatmap.HitObjects.Count + beatmap.HitObjects.OfType<Slider>().Sum(s => s.NestedHitObjects.Count - 1));
+            var beatmapMaxCombo = beatmap.HitObjects.Count + beatmap.HitObjects.OfType<Slider>().Sum(s => s.NestedHitObjects.Count - 1);
+            var maxCombo = command.Combo ??
+                           (int) Math.Round((command.PercentCombo ?? 100)/100 * beatmapMaxCombo);
             var statistics = generateHitResults(accuracy, beatmap, command.Misses ?? 0);
 
             var scoreInfo = new ScoreInfo()
@@ -55,7 +57,7 @@ namespace PerformanceCalculator.Simulate.Osu
             command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
 
             writeAttribute("Accuracy", (accuracy*100).ToString(CultureInfo.InvariantCulture) + "%");
-            writeAttribute("Max Combo", maxCombo.ToString(CultureInfo.InvariantCulture));
+            writeAttribute("Combo", FormattableString.Invariant($"{maxCombo} ({Math.Round(100.0 * maxCombo/beatmapMaxCombo, 2)}%)"));
             writeAttribute("Misses", statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
 
             writeAttribute("Mods", mods.Length > 0

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
@@ -5,94 +5,23 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
 namespace PerformanceCalculator.Simulate.Osu
 {
-    public class OsuSimulateProcessor : IProcessor
+    public class OsuSimulateProcessor : BaseSimulateProcessor
     {
-        private readonly OsuSimulateCommand command;
+        protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.HitObjects.Count + beatmap.HitObjects.OfType<Slider>().Sum(s => s.NestedHitObjects.Count - 1);
 
-        public OsuSimulateProcessor(OsuSimulateCommand command)
-        {
-            this.command = command;
-        }
-
-        public void Execute()
-        {
-            var ruleset = new OsuRuleset();
-
-            var mods = getMods(ruleset).ToArray();
-
-            var workingBeatmap = new ProcessorWorkingBeatmap(command.Beatmap);
-            workingBeatmap.Mods.Value = mods;
-
-            var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
-
-            var accuracy = command.Accuracy / 100 ?? 1.0;
-            var beatmapMaxCombo = beatmap.HitObjects.Count + beatmap.HitObjects.OfType<Slider>().Sum(s => s.NestedHitObjects.Count - 1);
-            var maxCombo = command.Combo ??
-                           (int)Math.Round((command.PercentCombo ?? 100) / 100 * beatmapMaxCombo);
-            var statistics = generateHitResults(accuracy, beatmap, command.Misses ?? 0);
-
-            var scoreInfo = new ScoreInfo
-            {
-                Accuracy = accuracy,
-                MaxCombo = maxCombo,
-                Statistics = statistics,
-                Mods = mods
-            };
-
-            var categoryAttribs = new Dictionary<string, double>();
-            double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
-
-            command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
-
-            writeAttribute("Accuracy", (accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
-            writeAttribute("Combo", FormattableString.Invariant($"{maxCombo} ({Math.Round(100.0 * maxCombo / beatmapMaxCombo, 2)}%)"));
-            writeAttribute("Misses", statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
-
-            writeAttribute("Mods", mods.Length > 0
-                ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")
-                : "None");
-
-            foreach (var kvp in categoryAttribs)
-                writeAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
-
-            writeAttribute("pp", pp.ToString(CultureInfo.InvariantCulture));
-        }
-
-        private List<Mod> getMods(Ruleset ruleset)
-        {
-            var mods = new List<Mod>();
-            if (command.Mods == null)
-                return mods;
-
-            var availableMods = ruleset.GetAllMods().ToList();
-            foreach (var modString in command.Mods)
-            {
-                Mod newMod = availableMods.FirstOrDefault(m => string.Equals(m.Acronym, modString, StringComparison.CurrentCultureIgnoreCase));
-                if (newMod == null)
-                    throw new ArgumentException($"Invalid mod provided: {modString}");
-                mods.Add(newMod);
-            }
-
-            return mods;
-        }
-
-        private Dictionary<HitResult, int> generateHitResults(double accuracy, IBeatmap beatmap, int amountMiss)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int amountMiss)
         {
             var totalHitObjects = beatmap.HitObjects.Count;
 
             // Let Great=6, Good=2, Meh=1, Miss=0. The total should be this.
-            var targetTotal = (int)Math.Round(accuracy * totalHitObjects * 6);
+            var targetTotal = (int)Math.Round(accuracy*totalHitObjects*6);
 
             // Start by assuming every non miss is a meh
             // This is how much increase is needed by greats and goods
@@ -114,6 +43,16 @@ namespace PerformanceCalculator.Simulate.Osu
             };
         }
 
-        private void writeAttribute(string name, string value) => command.Console.WriteLine($"{name.PadRight(15)}: {value}");
+        protected override void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
+        {
+            WriteAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
+            WriteAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)"));
+            WriteAttribute("Misses", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
+        }
+
+        public OsuSimulateProcessor(BaseSimulateCommand command)
+            : base(command)
+        {
+        }
     }
 }

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
@@ -16,38 +16,61 @@ namespace PerformanceCalculator.Simulate.Osu
     {
         protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.HitObjects.Count + beatmap.HitObjects.OfType<Slider>().Sum(s => s.NestedHitObjects.Count - 1);
 
-        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int amountMiss)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
         {
-            var totalHitObjects = beatmap.HitObjects.Count;
+            int countGreat;
 
-            // Let Great=6, Good=2, Meh=1, Miss=0. The total should be this.
-            var targetTotal = (int)Math.Round(accuracy*totalHitObjects*6);
+            var totalResultCount = beatmap.HitObjects.Count;
 
-            // Start by assuming every non miss is a meh
-            // This is how much increase is needed by greats and goods
-            var delta = targetTotal - (totalHitObjects - amountMiss);
+            if (countMeh != null || countGood != null)
+            {
+                countGreat = totalResultCount - (countGood ?? 0) - (countMeh ?? 0) - countMiss;
+            }
+            else
+            {
+                // Let Great=6, Good=2, Meh=1, Miss=0. The total should be this.
+                var targetTotal = (int)Math.Round(accuracy * totalResultCount * 6);
 
-            // Each great increases total by 5 (great-meh=5)
-            var amountGreat = delta / 5;
-            // Each good increases total by 1 (good-meh=1). Covers remaining difference.
-            var amountGood = delta % 5;
-            // Mehs are left over. Could be negative if impossible value of amountMiss chosen
-            var amountMeh = totalHitObjects - amountGreat - amountGood - amountMiss;
+                // Start by assuming every non miss is a meh
+                // This is how much increase is needed by greats and goods
+                var delta = targetTotal - (totalResultCount - countMiss);
+
+                // Each great increases total by 5 (great-meh=5)
+                countGreat = delta / 5;
+                // Each good increases total by 1 (good-meh=1). Covers remaining difference.
+                countGood = delta % 5;
+                // Mehs are left over. Could be negative if impossible value of amountMiss chosen
+                countMeh = totalResultCount - countGreat - countGood - countMiss;
+            }
 
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Great, amountGreat },
-                { HitResult.Good, amountGood },
-                { HitResult.Meh, amountMeh },
-                { HitResult.Miss, amountMiss }
+                { HitResult.Great, countGreat },
+                { HitResult.Good, countGood ?? 0 },
+                { HitResult.Meh, countMeh ?? 0 },
+                { HitResult.Miss, countMiss }
             };
+        }
+
+        protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
+        {
+            var countGreat = statistics[HitResult.Great];
+            var countGood = statistics[HitResult.Good];
+            var countMeh = statistics[HitResult.Meh];
+            var countMiss = statistics[HitResult.Miss];
+            var total = countGreat + countGood + countMeh + countMiss;
+
+            return (double)((6 * countGreat) + (2 * countGood) + countMeh) / (6 * total);
         }
 
         protected override void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
         {
             WriteAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
             WriteAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)"));
-            WriteAttribute("Misses", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
+            foreach (var statistic in scoreInfo.Statistics)
+            {
+                WriteAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture));
+            }
         }
 
         public OsuSimulateProcessor(BaseSimulateCommand command)

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
@@ -36,10 +36,10 @@ namespace PerformanceCalculator.Simulate.Osu
 
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
 
-            var accuracy = command.Accuracy/100 ?? 1.0;
+            var accuracy = command.Accuracy / 100 ?? 1.0;
             var beatmapMaxCombo = beatmap.HitObjects.Count + beatmap.HitObjects.OfType<Slider>().Sum(s => s.NestedHitObjects.Count - 1);
             var maxCombo = command.Combo ??
-                           (int) Math.Round((command.PercentCombo ?? 100)/100 * beatmapMaxCombo);
+                           (int)Math.Round((command.PercentCombo ?? 100) / 100 * beatmapMaxCombo);
             var statistics = generateHitResults(accuracy, beatmap, command.Misses ?? 0);
 
             var scoreInfo = new ScoreInfo
@@ -55,8 +55,8 @@ namespace PerformanceCalculator.Simulate.Osu
 
             command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
 
-            writeAttribute("Accuracy", (accuracy*100).ToString(CultureInfo.InvariantCulture) + "%");
-            writeAttribute("Combo", FormattableString.Invariant($"{maxCombo} ({Math.Round(100.0 * maxCombo/beatmapMaxCombo, 2)}%)"));
+            writeAttribute("Accuracy", (accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
+            writeAttribute("Combo", FormattableString.Invariant($"{maxCombo} ({Math.Round(100.0 * maxCombo / beatmapMaxCombo, 2)}%)"));
             writeAttribute("Misses", statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
 
             writeAttribute("Mods", mods.Length > 0
@@ -92,7 +92,7 @@ namespace PerformanceCalculator.Simulate.Osu
             var totalHitObjects = beatmap.HitObjects.Count;
 
             // Let Great=6, Good=2, Meh=1, Miss=0. The total should be this.
-            var targetTotal = (int) Math.Round(accuracy*totalHitObjects*6);
+            var targetTotal = (int)Math.Round(accuracy * totalHitObjects * 6);
 
             // Start by assuming every non miss is a meh
             // This is how much increase is needed by greats and goods
@@ -107,10 +107,10 @@ namespace PerformanceCalculator.Simulate.Osu
 
             return new Dictionary<HitResult, int>
             {
-                {HitResult.Great, amountGreat},
-                {HitResult.Good, amountGood},
-                {HitResult.Meh, amountMeh},
-                {HitResult.Miss, amountMiss}
+                { HitResult.Great, amountGreat },
+                { HitResult.Good, amountGood },
+                { HitResult.Meh, amountMeh },
+                { HitResult.Miss, amountMiss }
             };
         }
 

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
@@ -48,7 +48,6 @@ namespace PerformanceCalculator.Simulate.Osu
                 MaxCombo = maxCombo,
                 Statistics = statistics,
                 Mods = mods
-
             };
 
             var categoryAttribs = new Dictionary<string, double>();
@@ -105,7 +104,6 @@ namespace PerformanceCalculator.Simulate.Osu
             var amountGood = delta % 5;
             // Mehs are left over. Could be negative if impossible value of amountMiss chosen
             var amountMeh = totalHitObjects - amountGreat - amountGood - amountMiss;
-
 
             return new Dictionary<HitResult, int>()
             {

--- a/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Osu/OsuSimulateProcessor.cs
@@ -1,5 +1,5 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
 
 using System;
 using System.Collections.Generic;

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -1,5 +1,5 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
 
 using McMaster.Extensions.CommandLineUtils;
 using PerformanceCalculator.Simulate.Mania;

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -1,37 +1,20 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
-using System.ComponentModel.DataAnnotations;
-using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
+using PerformanceCalculator.Simulate.Osu;
 
 namespace PerformanceCalculator.Simulate
 {
-    [Command(Name = "performance", Description = "Computes the performance (pp) of a simulated play. Only works on osu standard for now.")]
-    public class SimulateCommand : ProcessorCommand
+    [Command(Name = "performance", Description = "Computes the performance (pp) of a simulated play.")]
+    [Subcommand("osu", typeof(OsuSimulateCommand))]
+    public class SimulateCommand : CommandBase
     {
-        [UsedImplicitly]
-        [Required, FileExists]
-        [Argument(0, Name = "beatmap", Description = "Required. The beatmap file (.osu).")]
-        public string Beatmap { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales number of 300s and 100s as well.")]
-        public double? Accuracy { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-c|--combo|--max-combo <combo>", Description = "Max Combo. Enter as integer. Defaults to beatmap maximum.")]
-        public int? MaxCombo { get; }
-
-        [UsedImplicitly]
-        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                            + "Values: hr, dt, hd, fl, ez, etc...")]
-        public string[] Mods { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-M|--misses <misses>", Description = "Number of misses. Enter as integer.")]
-        public int? Misses { get; }
-
-        protected override IProcessor CreateProcessor() => new SimulateProcessor(this);
+        public int OnExecute(CommandLineApplication app, IConsole console)
+        {
+            console.WriteLine("You must specify a subcommand.");
+            app.ShowHelp();
+            return 1;
+        }
     }
 }

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -1,0 +1,33 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
+
+using System.ComponentModel.DataAnnotations;
+using JetBrains.Annotations;
+using McMaster.Extensions.CommandLineUtils;
+
+namespace PerformanceCalculator.Simulate
+{
+    [Command(Name = "performance", Description = "Computes the performance (pp) of a simulated play.")]
+    public class SimulateCommand : ProcessorCommand
+    {
+        [UsedImplicitly]
+        [Required, FileExists]
+        [Argument(0, Name = "beatmap", Description = "Required. The beatmap file (.osu).")]
+        public string Beatmap { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-a|--accuracy <value>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales number of 300s and 100s as well.")]
+        public double? Accuracy { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-c|--combo <value>", Description = "Max Combo. Enter as integer. Defaults to beatmap maximum.")]
+        public int? MaxCombo { get; }
+
+        [UsedImplicitly]
+        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
+                                                                                          + "Values: hr, dt, hd, fl, ez, etc...")]
+        public string[] Mods { get; }
+
+        protected override IProcessor CreateProcessor() => new SimulateProcessor(this);
+    }
+}

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -7,7 +7,7 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace PerformanceCalculator.Simulate
 {
-    [Command(Name = "performance", Description = "Computes the performance (pp) of a simulated play.")]
+    [Command(Name = "performance", Description = "Computes the performance (pp) of a simulated play. Only works on osu standard for now.")]
     public class SimulateCommand : ProcessorCommand
     {
         [UsedImplicitly]
@@ -16,17 +16,21 @@ namespace PerformanceCalculator.Simulate
         public string Beatmap { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <value>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales number of 300s and 100s as well.")]
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales number of 300s and 100s as well.")]
         public double? Accuracy { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-c|--combo <value>", Description = "Max Combo. Enter as integer. Defaults to beatmap maximum.")]
+        [Option(Template = "-c|--combo|--max-combo <combo>", Description = "Max Combo. Enter as integer. Defaults to beatmap maximum.")]
         public int? MaxCombo { get; }
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                          + "Values: hr, dt, hd, fl, ez, etc...")]
+                                                                                            + "Values: hr, dt, hd, fl, ez, etc...")]
         public string[] Mods { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-M|--misses <misses>", Description = "Number of misses. Enter as integer.")]
+        public int? Misses { get; }
 
         protected override IProcessor CreateProcessor() => new SimulateProcessor(this);
     }

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
 
 using McMaster.Extensions.CommandLineUtils;
+using PerformanceCalculator.Simulate.Mania;
 using PerformanceCalculator.Simulate.Osu;
 using PerformanceCalculator.Simulate.Taiko;
 
@@ -10,6 +11,7 @@ namespace PerformanceCalculator.Simulate
     [Command(Name = "performance", Description = "Computes the performance (pp) of a simulated play.")]
     [Subcommand("osu", typeof(OsuSimulateCommand))]
     [Subcommand("taiko", typeof(TaikoSimulateCommand))]
+    [Subcommand("mania", typeof(ManiaSimulateCommand))]
     public class SimulateCommand : CommandBase
     {
         public int OnExecute(CommandLineApplication app, IConsole console)

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -3,11 +3,13 @@
 
 using McMaster.Extensions.CommandLineUtils;
 using PerformanceCalculator.Simulate.Osu;
+using PerformanceCalculator.Simulate.Taiko;
 
 namespace PerformanceCalculator.Simulate
 {
     [Command(Name = "performance", Description = "Computes the performance (pp) of a simulated play.")]
     [Subcommand("osu", typeof(OsuSimulateCommand))]
+    [Subcommand("taiko", typeof(TaikoSimulateCommand))]
     public class SimulateCommand : CommandBase
     {
         public int OnExecute(CommandLineApplication app, IConsole console)

--- a/PerformanceCalculator/Simulate/SimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/SimulateProcessor.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Scoring;
+
+namespace PerformanceCalculator.Simulate
+{
+    public class SimulateProcessor : IProcessor
+    {
+        private readonly SimulateCommand command;
+
+        public SimulateProcessor(SimulateCommand command)
+        {
+            this.command = command;
+        }
+
+        public void Execute()
+        {
+            var ruleset = new OsuRuleset();
+            var workingBeatmap = new ProcessorWorkingBeatmap(command.Beatmap);
+            var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
+
+            var accuracy = command.Accuracy/100 ?? 1.0;
+            var maxCombo = command.MaxCombo ?? (beatmap.HitObjects.Count + beatmap.HitObjects.OfType<Slider>().Sum(s => s.NestedHitObjects.Count - 1));
+            var statistics = generateHitResults(accuracy, beatmap);
+            var mods = getMods(ruleset).ToArray();
+
+            var scoreInfo = new ScoreInfo()
+            {
+                Accuracy = accuracy,
+                MaxCombo = maxCombo,
+                Statistics = statistics,
+                Mods = mods
+
+            };
+
+            workingBeatmap.Mods.Value = mods;
+
+            var categoryAttribs = new Dictionary<string, double>();
+            double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
+
+            foreach (var kvp in categoryAttribs)
+                writeAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
+
+            writeAttribute("pp", pp.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private List<Mod> getMods(Ruleset ruleset)
+        {
+            var mods = new List<Mod>();
+            if (command.Mods == null)
+                return mods;
+
+            var availableMods = ruleset.GetAllMods().ToList();
+            foreach (var modString in command.Mods)
+            {
+                Mod newMod = availableMods.FirstOrDefault(m => string.Equals(m.Acronym, modString, StringComparison.CurrentCultureIgnoreCase));
+                if (newMod == null)
+                    throw new ArgumentException($"Invalid mod provided: {modString}");
+                mods.Add(newMod);
+            }
+
+            return mods;
+        }
+
+        private Dictionary<HitResult, int> generateHitResults(double accuracy, IBeatmap beatmap)
+        {
+            var amountHitObjects = beatmap.HitObjects.Count();
+            var good = (int) Math.Round((1-accuracy) * amountHitObjects * 300/200);
+            var great = amountHitObjects - good;
+            return new Dictionary<HitResult, int>()
+            {
+                {HitResult.Great, great},
+                {HitResult.Good, good},
+                {HitResult.Meh, 0},
+                {HitResult.Miss, 0}
+            };
+        }
+
+        private void writeAttribute(string name, string value) => command.Console.WriteLine($"{name.PadRight(15)}: {value}");
+    }
+}

--- a/PerformanceCalculator/Simulate/SimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/SimulateProcessor.cs
@@ -50,6 +50,8 @@ namespace PerformanceCalculator.Simulate
             var categoryAttribs = new Dictionary<string, double>();
             double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
 
+            command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
+
             foreach (var kvp in categoryAttribs)
                 writeAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
 

--- a/PerformanceCalculator/Simulate/SimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/SimulateProcessor.cs
@@ -52,6 +52,10 @@ namespace PerformanceCalculator.Simulate
 
             command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
 
+            writeAttribute("Mods", mods.Length > 0
+                ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")
+                : "None");
+
             foreach (var kvp in categoryAttribs)
                 writeAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
 

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
@@ -5,10 +5,10 @@ using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 
-namespace PerformanceCalculator.Simulate.Osu
+namespace PerformanceCalculator.Simulate.Taiko
 {
-    [Command(Name = "simulate osu", Description = "Computes the performance (pp) of a simulated osu play.")]
-    public class OsuSimulateCommand : ProcessorCommand
+    [Command(Name = "simulate taiko", Description = "Computes the performance (pp) of a simulated taiko play.")]
+    public class TaikoSimulateCommand : ProcessorCommand
     {
         [UsedImplicitly]
         [Required, FileExists]
@@ -16,7 +16,7 @@ namespace PerformanceCalculator.Simulate.Osu
         public string Beatmap { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well.")]
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100.")]
         public double? Accuracy { get; }
 
         [UsedImplicitly]
@@ -32,6 +32,6 @@ namespace PerformanceCalculator.Simulate.Osu
         [Option(Template = "-M|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
         public int? Misses { get; }
 
-        protected override IProcessor CreateProcessor() => new OsuSimulateProcessor(this);
+        protected override IProcessor CreateProcessor() => new TaikoSimulateProcessor(this);
     }
 }

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
@@ -4,38 +4,42 @@
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Taiko;
 
 namespace PerformanceCalculator.Simulate.Taiko
 {
     [Command(Name = "simulate taiko", Description = "Computes the performance (pp) of a simulated osu!taiko play.")]
-    public class TaikoSimulateCommand : ProcessorCommand
+    public class TaikoSimulateCommand : BaseSimulateCommand
     {
         [UsedImplicitly]
         [Required, FileExists]
         [Argument(0, Name = "beatmap", Description = "Required. The beatmap file (.osu).")]
-        public string Beatmap { get; }
+        public override string Beatmap { get; }
 
         [UsedImplicitly]
         [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100.")]
-        public double? Accuracy { get; }
+        public override double Accuracy { get; } = 100;
 
         [UsedImplicitly]
         [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]
-        public int? Combo { get; }
+        public override int? Combo { get; }
 
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
                                                                        + " Enter as decimal 0-100.")]
-        public double? PercentCombo { get; }
+        public override double PercentCombo { get; } = 100;
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
                                                                                             + " Values: hr, dt, hd, fl, ez, etc...")]
-        public string[] Mods { get; }
+        public override string[] Mods { get; }
 
         [UsedImplicitly]
         [Option(Template = "-M|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
-        public int? Misses { get; }
+        public override int Misses { get; }
+
+        public override Ruleset Ruleset => new TaikoRuleset();
 
         protected override IProcessor CreateProcessor() => new TaikoSimulateProcessor(this);
     }

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
@@ -18,7 +18,8 @@ namespace PerformanceCalculator.Simulate.Taiko
         public override string Beatmap { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100.")]
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
+                                                                     + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
         public override double Accuracy { get; } = 100;
 
         [UsedImplicitly]
@@ -36,8 +37,12 @@ namespace PerformanceCalculator.Simulate.Taiko
         public override string[] Mods { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-M|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
+        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
         public override int Misses { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Goods { get; }
 
         public override Ruleset Ruleset => new TaikoRuleset();
 

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
@@ -20,8 +20,13 @@ namespace PerformanceCalculator.Simulate.Taiko
         public double? Accuracy { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-c|--combo|--max-combo <combo>", Description = "Maximum Combo. Defaults to beatmap maximum.")]
-        public int? MaxCombo { get; }
+        [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]
+        public int? Combo { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
+                                                                       + " Enter as decimal 0-100.")]
+        public double? PercentCombo { get; }
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
@@ -7,7 +7,7 @@ using McMaster.Extensions.CommandLineUtils;
 
 namespace PerformanceCalculator.Simulate.Taiko
 {
-    [Command(Name = "simulate taiko", Description = "Computes the performance (pp) of a simulated taiko play.")]
+    [Command(Name = "simulate taiko", Description = "Computes the performance (pp) of a simulated osu!taiko play.")]
     public class TaikoSimulateCommand : ProcessorCommand
     {
         [UsedImplicitly]

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateCommand.cs
@@ -30,7 +30,7 @@ namespace PerformanceCalculator.Simulate.Taiko
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                            + "Values: hr, dt, hd, fl, ez, etc...")]
+                                                                                            + " Values: hr, dt, hd, fl, ez, etc...")]
         public string[] Mods { get; }
 
         [UsedImplicitly]

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
@@ -28,13 +28,17 @@ namespace PerformanceCalculator.Simulate.Taiko
         public void Execute()
         {
             var ruleset = new TaikoRuleset();
+
+            var mods = getMods(ruleset).ToArray();
+
             var workingBeatmap = new ProcessorWorkingBeatmap(command.Beatmap);
+            workingBeatmap.Mods.Value = mods;
+
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
 
             var accuracy = command.Accuracy/100 ?? 1.0;
             var maxCombo = command.MaxCombo ?? beatmap.HitObjects.OfType<Hit>().Count();
             var statistics = generateHitResults(beatmap, command.Misses ?? 0);
-            var mods = getMods(ruleset).ToArray();
 
             var scoreInfo = new ScoreInfo()
             {
@@ -51,6 +55,10 @@ namespace PerformanceCalculator.Simulate.Taiko
             double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
 
             command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
+
+            writeAttribute("Accuracy", (accuracy*100).ToString(CultureInfo.InvariantCulture) + "%");
+            writeAttribute("Max Combo", maxCombo.ToString(CultureInfo.InvariantCulture));
+            writeAttribute("Misses", statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
 
             writeAttribute("Mods", mods.Length > 0
                 ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
@@ -5,91 +5,18 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
-using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Rulesets.Taiko;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Scoring;
 
 namespace PerformanceCalculator.Simulate.Taiko
 {
-    public class TaikoSimulateProcessor : IProcessor
+    public class TaikoSimulateProcessor : BaseSimulateProcessor
     {
-        private readonly TaikoSimulateCommand command;
+        protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.HitObjects.OfType<Hit>().Count();
 
-        public TaikoSimulateProcessor(TaikoSimulateCommand command)
-        {
-            this.command = command;
-        }
-
-        public void Execute()
-        {
-            var ruleset = new TaikoRuleset();
-
-            var mods = getMods(ruleset).ToArray();
-
-            var workingBeatmap = new ProcessorWorkingBeatmap(command.Beatmap);
-            workingBeatmap.Mods.Value = mods;
-
-            var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
-
-            var accuracy = command.Accuracy / 100 ?? 1.0;
-            var beatmapMaxCombo = beatmap.HitObjects.OfType<Hit>().Count();
-            var maxCombo = command.Combo ??
-                           (int)Math.Round((command.PercentCombo ?? 100) / 100 * beatmapMaxCombo);
-            var statistics = generateHitResults(beatmap, command.Misses ?? 0);
-
-            var scoreInfo = new ScoreInfo
-            {
-                Accuracy = accuracy,
-                MaxCombo = maxCombo,
-                Statistics = statistics,
-                Mods = mods
-            };
-
-            workingBeatmap.Mods.Value = mods;
-
-            var categoryAttribs = new Dictionary<string, double>();
-            double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
-
-            command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
-
-            writeAttribute("Accuracy", (accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
-            writeAttribute("Combo", FormattableString.Invariant($"{maxCombo}/{beatmapMaxCombo} ({Math.Round(100.0 * maxCombo / beatmapMaxCombo, 2)}%)"));
-            writeAttribute("Misses", statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
-
-            writeAttribute("Mods", mods.Length > 0
-                ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")
-                : "None");
-
-            foreach (var kvp in categoryAttribs)
-                writeAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
-
-            writeAttribute("pp", pp.ToString(CultureInfo.InvariantCulture));
-        }
-
-        private List<Mod> getMods(Ruleset ruleset)
-        {
-            var mods = new List<Mod>();
-            if (command.Mods == null)
-                return mods;
-
-            var availableMods = ruleset.GetAllMods().ToList();
-            foreach (var modString in command.Mods)
-            {
-                Mod newMod = availableMods.FirstOrDefault(m => string.Equals(m.Acronym, modString, StringComparison.CurrentCultureIgnoreCase));
-                if (newMod == null)
-                    throw new ArgumentException($"Invalid mod provided: {modString}");
-                mods.Add(newMod);
-            }
-
-            return mods;
-        }
-
-        private Dictionary<HitResult, int> generateHitResults(IBeatmap beatmap, int amountMiss)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int amountMiss)
         {
             var totalHitObjects = beatmap.HitObjects.Count;
 
@@ -105,6 +32,16 @@ namespace PerformanceCalculator.Simulate.Taiko
             };
         }
 
-        private void writeAttribute(string name, string value) => command.Console.WriteLine($"{name.PadRight(15)}: {value}");
+        protected override void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
+        {
+            WriteAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
+            WriteAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)"));
+            WriteAttribute("Misses", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
+        }
+
+        public TaikoSimulateProcessor(BaseSimulateCommand command)
+            : base(command)
+        {
+        }
     }
 }

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
@@ -1,0 +1,101 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using McMaster.Extensions.CommandLineUtils;
+using osu.Game.Beatmaps;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Scoring;
+using osu.Game.Rulesets.Taiko;
+using osu.Game.Rulesets.Taiko.Objects;
+using osu.Game.Scoring;
+
+namespace PerformanceCalculator.Simulate.Taiko
+{
+    public class TaikoSimulateProcessor : IProcessor
+    {
+        private readonly TaikoSimulateCommand command;
+
+        public TaikoSimulateProcessor(TaikoSimulateCommand command)
+        {
+            this.command = command;
+        }
+
+        public void Execute()
+        {
+            var ruleset = new TaikoRuleset();
+            var workingBeatmap = new ProcessorWorkingBeatmap(command.Beatmap);
+            var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
+
+            var accuracy = command.Accuracy/100 ?? 1.0;
+            var maxCombo = command.MaxCombo ?? beatmap.HitObjects.OfType<Hit>().Count();
+            var statistics = generateHitResults(beatmap, command.Misses ?? 0);
+            var mods = getMods(ruleset).ToArray();
+
+            var scoreInfo = new ScoreInfo()
+            {
+                Accuracy = accuracy,
+                MaxCombo = maxCombo,
+                Statistics = statistics,
+                Mods = mods
+
+            };
+
+            workingBeatmap.Mods.Value = mods;
+
+            var categoryAttribs = new Dictionary<string, double>();
+            double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
+
+            command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
+
+            writeAttribute("Mods", mods.Length > 0
+                ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")
+                : "None");
+
+            foreach (var kvp in categoryAttribs)
+                writeAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
+
+            writeAttribute("pp", pp.ToString(CultureInfo.InvariantCulture));
+        }
+
+        private List<Mod> getMods(Ruleset ruleset)
+        {
+            var mods = new List<Mod>();
+            if (command.Mods == null)
+                return mods;
+
+            var availableMods = ruleset.GetAllMods().ToList();
+            foreach (var modString in command.Mods)
+            {
+                Mod newMod = availableMods.FirstOrDefault(m => string.Equals(m.Acronym, modString, StringComparison.CurrentCultureIgnoreCase));
+                if (newMod == null)
+                    throw new ArgumentException($"Invalid mod provided: {modString}");
+                mods.Add(newMod);
+            }
+
+            return mods;
+        }
+
+        private Dictionary<HitResult, int> generateHitResults(IBeatmap beatmap, int amountMiss)
+        {
+            var totalHitObjects = beatmap.HitObjects.Count();
+
+            // Does not need to match acc currently since only total and miss count matters
+            var amountGreat = totalHitObjects - amountMiss;
+
+            return new Dictionary<HitResult, int>()
+            {
+                {HitResult.Great, amountGreat},
+                {HitResult.Good, 0},
+                {HitResult.Meh, 0},
+                {HitResult.Miss, amountMiss}
+            };
+        }
+
+        private void writeAttribute(string name, string value) => command.Console.WriteLine($"{name.PadRight(15)}: {value}");
+    }
+}

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
@@ -37,7 +37,9 @@ namespace PerformanceCalculator.Simulate.Taiko
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
 
             var accuracy = command.Accuracy/100 ?? 1.0;
-            var maxCombo = command.MaxCombo ?? beatmap.HitObjects.OfType<Hit>().Count();
+            var beatmapMaxCombo = beatmap.HitObjects.OfType<Hit>().Count();
+            var maxCombo = command.Combo ??
+                           (int) Math.Round((command.PercentCombo ?? 100)/100 * beatmapMaxCombo);
             var statistics = generateHitResults(beatmap, command.Misses ?? 0);
 
             var scoreInfo = new ScoreInfo()
@@ -57,7 +59,7 @@ namespace PerformanceCalculator.Simulate.Taiko
             command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
 
             writeAttribute("Accuracy", (accuracy*100).ToString(CultureInfo.InvariantCulture) + "%");
-            writeAttribute("Max Combo", maxCombo.ToString(CultureInfo.InvariantCulture));
+            writeAttribute("Combo", FormattableString.Invariant($"{maxCombo}/{beatmapMaxCombo} ({Math.Round(100.0 * maxCombo/beatmapMaxCombo, 2)}%)"));
             writeAttribute("Misses", statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
 
             writeAttribute("Mods", mods.Length > 0

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
@@ -48,7 +48,6 @@ namespace PerformanceCalculator.Simulate.Taiko
                 MaxCombo = maxCombo,
                 Statistics = statistics,
                 Mods = mods
-
             };
 
             workingBeatmap.Mods.Value = mods;

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
@@ -42,7 +42,7 @@ namespace PerformanceCalculator.Simulate.Taiko
                            (int) Math.Round((command.PercentCombo ?? 100)/100 * beatmapMaxCombo);
             var statistics = generateHitResults(beatmap, command.Misses ?? 0);
 
-            var scoreInfo = new ScoreInfo()
+            var scoreInfo = new ScoreInfo
             {
                 Accuracy = accuracy,
                 MaxCombo = maxCombo,
@@ -91,12 +91,12 @@ namespace PerformanceCalculator.Simulate.Taiko
 
         private Dictionary<HitResult, int> generateHitResults(IBeatmap beatmap, int amountMiss)
         {
-            var totalHitObjects = beatmap.HitObjects.Count();
+            var totalHitObjects = beatmap.HitObjects.Count;
 
             // Does not need to match acc currently since only total and miss count matters
             var amountGreat = totalHitObjects - amountMiss;
 
-            return new Dictionary<HitResult, int>()
+            return new Dictionary<HitResult, int>
             {
                 {HitResult.Great, amountGreat},
                 {HitResult.Good, 0},

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
@@ -36,10 +36,10 @@ namespace PerformanceCalculator.Simulate.Taiko
 
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo);
 
-            var accuracy = command.Accuracy/100 ?? 1.0;
+            var accuracy = command.Accuracy / 100 ?? 1.0;
             var beatmapMaxCombo = beatmap.HitObjects.OfType<Hit>().Count();
             var maxCombo = command.Combo ??
-                           (int) Math.Round((command.PercentCombo ?? 100)/100 * beatmapMaxCombo);
+                           (int)Math.Round((command.PercentCombo ?? 100) / 100 * beatmapMaxCombo);
             var statistics = generateHitResults(beatmap, command.Misses ?? 0);
 
             var scoreInfo = new ScoreInfo
@@ -57,8 +57,8 @@ namespace PerformanceCalculator.Simulate.Taiko
 
             command.Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
 
-            writeAttribute("Accuracy", (accuracy*100).ToString(CultureInfo.InvariantCulture) + "%");
-            writeAttribute("Combo", FormattableString.Invariant($"{maxCombo}/{beatmapMaxCombo} ({Math.Round(100.0 * maxCombo/beatmapMaxCombo, 2)}%)"));
+            writeAttribute("Accuracy", (accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
+            writeAttribute("Combo", FormattableString.Invariant($"{maxCombo}/{beatmapMaxCombo} ({Math.Round(100.0 * maxCombo / beatmapMaxCombo, 2)}%)"));
             writeAttribute("Misses", statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
 
             writeAttribute("Mods", mods.Length > 0
@@ -98,10 +98,10 @@ namespace PerformanceCalculator.Simulate.Taiko
 
             return new Dictionary<HitResult, int>
             {
-                {HitResult.Great, amountGreat},
-                {HitResult.Good, 0},
-                {HitResult.Meh, 0},
-                {HitResult.Miss, amountMiss}
+                { HitResult.Great, amountGreat },
+                { HitResult.Good, 0 },
+                { HitResult.Meh, 0 },
+                { HitResult.Miss, amountMiss }
             };
         }
 

--- a/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
+++ b/PerformanceCalculator/Simulate/Taiko/TaikoSimulateProcessor.cs
@@ -1,5 +1,5 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-tools/master/LICENCE
 
 using System;
 using System.Collections.Generic;

--- a/osu.Tools.sln.DotSettings
+++ b/osu.Tools.sln.DotSettings
@@ -10,7 +10,8 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeAccessorOwnerBody/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeModifiersOrder/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeRedundantParentheses/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeRedundantParentheses/@EntryIndexedValue"></s:String>
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeRedundantParentheses/@EntryIndexRemoved">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeModifiers/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignedValueIsNeverUsed/@EntryIndexedValue">HINT</s:String>
@@ -25,6 +26,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassWithVirtualMembersNeverInherited_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CollectionNeverQueried_002EGlobal/@EntryIndexedValue">SUGGESTION</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CollectionNeverQueried_002ELocal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CommentTypo/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CompareOfFloatsByEqualityOperator/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertClosureToMethodGroup/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfDoToWhile/@EntryIndexedValue">WARNING</s:String>
@@ -44,7 +46,8 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EventNeverSubscribedTo_002ELocal/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002ELocal/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ForCanBeConvertedToForeach/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ForCanBeConvertedToForeach/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=IdentifierTypo/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ImpureMethodCallOnReadonlyValueField/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InheritdocConsiderUsage/@EntryIndexedValue">HINT</s:String>
@@ -135,6 +138,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithSingleOrDefault_002E2/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithSingleOrDefault_002E3/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithSingleOrDefault_002E4/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringLiteralTypo/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FBuiltInTypes/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FSimpleTypes/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SwitchStatementMissingSomeCases/@EntryIndexedValue">DO_NOT_SHOW</s:String>
@@ -217,6 +221,7 @@
   <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GMT/@EntryIndexedValue">GMT</s:String>
   <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=QAT/@EntryIndexedValue">QAT</s:String>
   <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=BNG/@EntryIndexedValue">BNG</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UI/@EntryIndexedValue">UI</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
@@ -664,6 +669,7 @@ Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/maste
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
Still needs some testing and cleanup

Adds a simulate subcommand to PerformanceCalculator which calculates the performance (and subattributes) a play with the given details would have on a beatmap.