### PR TITLE
Update documentation for ease of usability

### DIFF
--- a/PerformanceCalculator/README.md
+++ b/PerformanceCalculator/README.md
@@ -1,6 +1,6 @@
 # Performance Calculator
 
-A CLI tool for calculating the difficulty of beatmaps and the performance of replays.
+A tool for calculating the difficulty of beatmaps and the performance of replays.
 
 ## Tweaking
 
@@ -17,7 +17,7 @@ Difficulty and performance calculators for all rulesets may be modified to tweak
 
 ### Help
 ```
-> dotnet PerformanceCalculator.dll
+> dotnet run -- --help
 
 Usage: dotnet PerformanceCalculator.dll [options] [command]
 
@@ -27,6 +27,7 @@ Options:
 Commands:
   difficulty    Computes the difficulty of a beatmap.
   performance   Computes the performance (pp) of replays on a beatmap.
+  profile       Computes the total performance (pp) of a profile.
   simulate      Computes the performance (pp) of a simulated play.
 
 Run 'dotnet PerformanceCalculator.dll [command] --help' for more information about a command.
@@ -34,20 +35,21 @@ Run 'dotnet PerformanceCalculator.dll [command] --help' for more information abo
 
 ### Difficulty
 ```
-> dotnet PerformanceCalculator.dll difficulty --help
+> dotnet run -- difficulty --help
 
 Computes the difficulty of a beatmap.
 
 Usage: dotnet PerformanceCalculator.dll difficulty [arguments] [options]
 
 Arguments:
-  beatmap                    Required. The beatmap (.osu) to compute the difficulty for.
+  path                       Required. A beatmap file (.osu), or a folder containing .osu files to compute the difficulty for.
 
 Options:
   -?|-h|--help               Show help information
   -r|--ruleset:<ruleset-id>  Optional. The ruleset to compute the beatmap difficulty for, if it's a convertible beatmap.
                              Values: 0 - osu!, 1 - osu!taiko, 2 - osu!catch, 3 - osu!mania
   -m|--m <mod>               One for each mod. The mods to compute the difficulty with.Values: hr, dt, hd, fl, ez, 4k, 5k, etc...
+  -o|--output <file.txt>     Output results to text file.
 ```
 
 Computes the difficulty attributes of a beatmap. These attributes are used in performance calculation.
@@ -61,18 +63,19 @@ stars          : 4.69957066421573
 
 ### Performance
 ```
-> dotnet PerformanceCalculator.dll performance --help
+> dotnet run -- performance --help
 
 Computes the performance (pp) of replays on a beatmap.
 
 Usage: dotnet PerformanceCalculator.dll performance [arguments] [options]
 
 Arguments:
-  beatmap             Required. The beatmap file corresponding to the replays.
+  beatmap                 Required. The beatmap file (.osu) corresponding to the replays.
 
 Options:
-  -?|-h|--help        Show help information
-  -r|--replay <file>  One for each replay. The replay file.
+  -?|-h|--help            Show help information
+  -r|--replay <file>      One for each replay. The replay file.
+  -o|--output <file.txt>  Output results to text file.
 ```
 
 Computes the performance of one or more replays on a beatmap. The provided output includes raw performance attributes alongside the un-weighted pp value.
@@ -86,19 +89,20 @@ pp             : 235.580094436267
 
 ### Profile
 ```
-> dotnet PerformanceCalculator.dll profile --help
+> dotnet run -- profile --help
 
 Computes the total performance (pp) of a profile.
 
 Usage: dotnet PerformanceCalculator.dll profile [arguments] [options]
 
 Arguments:
-  user                 Required. User ID is preferred, but username should also work
-  api key              Required. API Key, which you can get from here: https://osu.ppy.sh/p/api
+  user                       User ID is preferred, but username should also work.
+  api key                    API Key, which you can get from here: https://osu.ppy.sh/p/api
 
 Options:
-  -?|-h|--help         Show help information
-  -r|--ruleset:<ruleset-id>  Optional. The ruleset to compute the profile for. 0 - osu!, 1 - osu!taiko, 2 - osu!catch, 3 - osu!mania. Defaults to osu!.
+  -?|-h|--help               Show help information
+  -r|--ruleset:<ruleset-id>  The ruleset to compute the profile for. 0 - osu!, 1 - osu!taiko, 2 - osu!catch, 3 - osu!mania. Defaults to osu!.
+  -o|--output <file.txt>     Output results to text file.
 ```
 
 Computes the performance of a user profile's performance. Takes 100 top plays of a user and recalculates and reorders them in order of the performance calculator's calculated performance.
@@ -130,7 +134,7 @@ Local PP: 766.7
 
 ### Simulate
 ```
-> dotnet PerformanceCalculator.dll simulate
+> dotnet run -- simulate --help
 
 Computes the performance (pp) of a simulated play.
 
@@ -140,19 +144,18 @@ Options:
   -?|-h|--help  Show help information
 
 Commands:
-  mania         Computes the performance (pp) of a simulated mania play.
-  osu           Computes the performance (pp) of a simulated osu play.
-  taiko         Computes the performance (pp) of a simulated taiko play.
+  mania         Computes the performance (pp) of a simulated osu!mania play.
+  osu           Computes the performance (pp) of a simulated osu! play.
+  taiko         Computes the performance (pp) of a simulated osu!taiko play.
 
 Run 'simulate [command] --help' for more information about a command.
-
 ```
 
 Computes the performance of a simulated play on a beatmap. The provided output includes raw performance attributes and pp value.
 
 #### osu!
 ```
-> dotnet PerformanceCalculator.dll simulate osu --help
+> dotnet run -- simulate osu --help
 
 Computes the performance (pp) of a simulated osu! play.
 
@@ -170,11 +173,12 @@ Options:
   -X|--misses <misses>        Number of misses. Defaults to 0.
   -M|--mehs <mehs>            Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.
   -G|--goods <goods>          Number of goods. Will override accuracy if used. Otherwise is automatically calculated.
+  -o|--output <file.txt>      Output results to text file.
 ```
 
 #### osu!taiko
 ```
-> dotnet PerformanceCalculator.dll simulate taiko --help
+> dotnet run -- simulate taiko --help
 
 Computes the performance (pp) of a simulated osu!taiko play.
 
@@ -191,21 +195,23 @@ Options:
   -m|--mod <mod>              One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, ez, etc...
   -X|--misses <misses>        Number of misses. Defaults to 0.
   -G|--goods <goods>          Number of goods. Will override accuracy if used. Otherwise is automatically calculated.
+  -o|--output <file.txt>      Output results to text file.
 ```
 
 #### osu!mania
 ```
-> dotnet PerformanceCalculator.dll simulate mania --help
+> dotnet run -- simulate mania --help
 
 Computes the performance (pp) of a simulated osu!mania play.
 
 Usage: dotnet PerformanceCalculator.dll simulate mania [arguments] [options]
 
 Arguments:
-  beatmap             Required. The beatmap file (.osu).
+  beatmap                 Required. The beatmap file (.osu).
 
 Options:
-  -?|-h|--help        Show help information
-  -s|--score <score>  Score. An integer 0-1000000.
-  -m|--mod <mod>      One for each mod. The mods to compute the performance with. Values: hr, dt, fl, 4k, 5k, etc...
+  -?|-h|--help            Show help information
+  -s|--score <score>      Score. An integer 0-1000000.
+  -m|--mod <mod>          One for each mod. The mods to compute the performance with. Values: hr, dt, fl, 4k, 5k, etc...
+  -o|--output <file.txt>  Output results to text file.
 ```

--- a/README.md
+++ b/README.md
@@ -2,17 +2,18 @@
 
 Tools for [osu!](https://osu.ppy.sh).
 
-For more detailed information see per-tool READMEs.
-
-- [PerformanceCalculator](https://github.com/ppy/osu-tools/blob/master/PerformanceCalculator/README.md) - A CLI tool for calculating the difficulty of beatmaps and the performance of replays.
-
 # Requirements
 
-- A desktop platform that can compile .NET 4.7.1. We recommend using [Visual Studio Community Edition](https://www.visualstudio.com/) (Windows), [Visual Studio for Mac](https://www.visualstudio.com/vs/visual-studio-mac/) (macOS) or [MonoDevelop](http://www.monodevelop.com/download/) (Linux), all of which are free. [Visual Studio Code](https://code.visualstudio.com/) may also be used but requires further setup steps which are not covered here.
+- A desktop platform with the [.NET Core SDK 2.2](https://www.microsoft.com/net/learn/get-started) or higher installed.
+- When working with the codebase, we recommend using an IDE with intellisense and syntax highlighting, such as [Visual Studio 2017+](https://visualstudio.microsoft.com/vs/), [Jetbrains Rider](https://www.jetbrains.com/rider/) or [Visual Studio Code](https://code.visualstudio.com/).
+- These instructions assume you have the the [CLI git client](https://git-scm.com/) installed, but any other GUI client such as GitKraken will suffice.
+- Note that there are **[additional requirements for Windows 7 and Windows 8.1](https://docs.microsoft.com/en-us/dotnet/core/windows-prerequisites?tabs=netcore2x)** which you may need to manually install if your operating system is not up-to-date.
 
 # Getting Started
+
 - Clone the repository including submodules (`git clone --recurse-submodules https://github.com/ppy/osu-tools`)
-- Build in your IDE of choice (recommended IDEs automatically restore nuget packages; if you are using an alternative make sure to `nuget restore`)
+- Navigate to each tool's directory and follow the instructions listed in the tool's README.
+    - [PerformanceCalculator](https://github.com/ppy/osu-tools/blob/master/PerformanceCalculator/README.md) - A tool for calculating the difficulty of beatmaps and the performance of replays.
 
 # Contributing
 


### PR DESCRIPTION
- Links to .NET Core 2.2 (as per ppy/osu).
- Links to git.
- Removes PerformanceCalculator.dll from the run command, by using dotnet run. Not going to add a blurb for `--no-build` because there's only 2-3 sec of build time for rebuilds.

Also updated submodule to stop "download xyz zip file and extract it here".