### PR TITLE
Enable tiered compilation to calculate faster.

### DIFF
--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -2,7 +2,8 @@
   <Import Project="..\osu.Tools.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TieredCompilation>true</TieredCompilation>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu\osu.Game.Rulesets.Catch\osu.Game.Rulesets.Catch.csproj" />


### PR DESCRIPTION
Tiered compilation can make calculation faster, especially when there are only a few beatmaps. See https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-2-1#jit-compiler-improvements

Here are the comparisons.
![image](https://user-images.githubusercontent.com/35132976/54674851-3884f480-4b38-11e9-8840-a87e1c1ef562.png)
