### PR TITLE
Fix unintended file output truncation/formatting issues in PerformanceCalculator

### DIFF
--- a/PerformanceCalculator/ProcessorCommand.cs
+++ b/PerformanceCalculator/ProcessorCommand.cs
@@ -31,7 +31,9 @@ namespace PerformanceCalculator
             // todo: make usable by other command
             using (var writer = new StringWriter())
             {
-                ConsoleRenderer.RenderDocumentToText(document, new TextRenderTarget(writer));
+                var rect = new Rect(0, 0, 250, Size.Infinity);
+
+                ConsoleRenderer.RenderDocumentToText(document, new TextRenderTarget(writer), rect);
 
                 var str = writer.GetStringBuilder().ToString();
 


### PR DESCRIPTION
With the [current implementation](https://github.com/ppy/osu-tools/blob/master/PerformanceCalculator/ProcessorCommand.cs#L34) of file output rendering, the exclusion of the optional renderRect argument [requires the library to rely on the variable Console.BufferWidth](https://github.com/Athari/CsConsoleFormat/blob/master/Alba.CsConsoleFormat/Formatting/ConsoleRenderer.cs#L20).  
This causes formatting issues in the text output when using consoles with inadequate width to support the performance table:
![image](https://user-images.githubusercontent.com/29696963/67934237-7d284200-fb95-11e9-8f7d-bad70d5e2fa1.png)

By creating a new Rect struct with a reasonable width parameter and passing it as an argument to the renderer, we can ensure that file output stays formatted correctly regardless of the Console buffer -- because there's absolutely no reason that output to a static format should be dependent on variable console width.  
![image](https://user-images.githubusercontent.com/29696963/67934371-c5476480-fb95-11e9-9475-dd1fd07e23f1.png)

