### PR TITLE
Add --json arg for simulate command and refactor to use OutputDocument method

### DIFF
--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -99,15 +99,19 @@ namespace PerformanceCalculator.Simulate
             return hits / total;
         }
 
-        protected override void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
+        protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
         {
-            WriteAttribute("ApproachRate", FormattableString.Invariant($"{beatmap.BeatmapInfo.BaseDifficulty.ApproachRate}"));
-            WriteAttribute("MaxCombo", FormattableString.Invariant($"{scoreInfo.MaxCombo}"));
+            var playInfo = new List<string>();
+
+            playInfo.Add(GetAttribute("ApproachRate", FormattableString.Invariant($"{beatmap.BeatmapInfo.BaseDifficulty.ApproachRate}")));
+            playInfo.Add(GetAttribute("MaxCombo", FormattableString.Invariant($"{scoreInfo.MaxCombo}")));
 
             foreach (var statistic in scoreInfo.Statistics)
             {
-                WriteAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture));
+                playInfo.Add(GetAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture)));
             }
+
+            return String.Join("\n", playInfo);
         }
     }
 }

--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -101,17 +101,18 @@ namespace PerformanceCalculator.Simulate
 
         protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
         {
-            var playInfo = new List<string>();
-
-            playInfo.Add(GetAttribute("ApproachRate", FormattableString.Invariant($"{beatmap.BeatmapInfo.BaseDifficulty.ApproachRate}")));
-            playInfo.Add(GetAttribute("MaxCombo", FormattableString.Invariant($"{scoreInfo.MaxCombo}")));
+            var playInfo = new List<string>
+            {
+                GetAttribute("ApproachRate", FormattableString.Invariant($"{beatmap.BeatmapInfo.BaseDifficulty.ApproachRate}")),
+                GetAttribute("MaxCombo", FormattableString.Invariant($"{scoreInfo.MaxCombo}"))
+            };
 
             foreach (var statistic in scoreInfo.Statistics)
             {
                 playInfo.Add(GetAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture)));
             }
 
-            return String.Join("\n", playInfo);
+            return string.Join("\n", playInfo);
         }
     }
 }

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -51,9 +51,9 @@ namespace PerformanceCalculator.Simulate
             };
         }
 
-        protected override void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
+        protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
         {
-            WriteAttribute("Score", scoreInfo.TotalScore.ToString(CultureInfo.InvariantCulture));
+            return GetAttribute("Score", scoreInfo.TotalScore.ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -109,17 +109,18 @@ namespace PerformanceCalculator.Simulate
 
         protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
         {
-            var playInfo = new List<string>();
-
-            playInfo.Add(GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"));
-            playInfo.Add(GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)")));
+            var playInfo = new List<string>
+            {
+                GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"),
+                GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)"))
+            };
 
             foreach (var statistic in scoreInfo.Statistics)
             {
                 playInfo.Add(GetAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture)));
             }
 
-            return String.Join("\n", playInfo);
+            return string.Join("\n", playInfo);
         }
     }
 }

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -107,15 +107,19 @@ namespace PerformanceCalculator.Simulate
             return (double)((6 * countGreat) + (2 * countGood) + countMeh) / (6 * total);
         }
 
-        protected override void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
+        protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
         {
-            WriteAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
-            WriteAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)"));
+            var playInfo = new List<string>();
+
+            playInfo.Add(GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"));
+            playInfo.Add(GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)")));
 
             foreach (var statistic in scoreInfo.Statistics)
             {
-                WriteAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture));
+                playInfo.Add(GetAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture)));
             }
+
+            return String.Join("\n", playInfo);
         }
     }
 }

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Alba.CsConsoleFormat;
 using JetBrains.Annotations;
-using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -74,18 +74,22 @@ namespace PerformanceCalculator.Simulate
             var categoryAttribs = new Dictionary<string, double>();
             double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
 
-            Console.WriteLine(workingBeatmap.BeatmapInfo.ToString());
+            var document = new Document();
 
-            WritePlayInfo(scoreInfo, beatmap);
+            document.Children.Add(new Span(workingBeatmap.BeatmapInfo.ToString()), "\n");
 
-            WriteAttribute("Mods", mods.Length > 0
+            document.Children.Add(new Span(GetPlayInfo(scoreInfo, beatmap)), "\n");
+
+            document.Children.Add(new Span(GetAttribute("Mods", mods.Length > 0
                 ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}")
-                : "None");
+                : "None")), "\n");
 
             foreach (var kvp in categoryAttribs)
-                WriteAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture));
+                document.Children.Add(new Span(GetAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture))), "\n");
 
-            WriteAttribute("pp", pp.ToString(CultureInfo.InvariantCulture));
+            document.Children.Add(new Span(GetAttribute("pp", pp.ToString(CultureInfo.InvariantCulture))));
+
+            OutputDocument(document);
         }
 
         private List<Mod> getMods(Ruleset ruleset)
@@ -108,7 +112,7 @@ namespace PerformanceCalculator.Simulate
             return mods;
         }
 
-        protected abstract void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap);
+        protected abstract string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap);
 
         protected abstract int GetMaxCombo(IBeatmap beatmap);
 
@@ -116,6 +120,6 @@ namespace PerformanceCalculator.Simulate
 
         protected virtual double GetAccuracy(Dictionary<HitResult, int> statistics) => 0;
 
-        protected void WriteAttribute(string name, string value) => Console.WriteLine($"{name.PadRight(15)}: {value}");
+        protected string GetAttribute(string name, string value) => $"{name.PadRight(15)}: {value}";
     }
 }

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -94,13 +94,17 @@ namespace PerformanceCalculator.Simulate
             return (double)((2 * countGreat) + countGood) / (2 * total);
         }
 
-        protected override void WritePlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
+        protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
         {
-            WriteAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%");
-            WriteAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)"));
-            WriteAttribute("Misses", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture));
-            WriteAttribute("Goods", scoreInfo.Statistics[HitResult.Good].ToString(CultureInfo.InvariantCulture));
-            WriteAttribute("Greats", scoreInfo.Statistics[HitResult.Great].ToString(CultureInfo.InvariantCulture));
+            var playInfo = new List<string>();
+
+            playInfo.Add(GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"));
+            playInfo.Add(GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)")));
+            playInfo.Add(GetAttribute("Misses", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture)));
+            playInfo.Add(GetAttribute("Goods", scoreInfo.Statistics[HitResult.Good].ToString(CultureInfo.InvariantCulture)));
+            playInfo.Add(GetAttribute("Greats", scoreInfo.Statistics[HitResult.Great].ToString(CultureInfo.InvariantCulture)));
+
+            return String.Join("\n", playInfo);
         }
     }
 }

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -96,15 +96,16 @@ namespace PerformanceCalculator.Simulate
 
         protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
         {
-            var playInfo = new List<string>();
+            var playInfo = new List<string>
+            {
+                GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"),
+                GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)")),
+                GetAttribute("Misses", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture)),
+                GetAttribute("Goods", scoreInfo.Statistics[HitResult.Good].ToString(CultureInfo.InvariantCulture)),
+                GetAttribute("Greats", scoreInfo.Statistics[HitResult.Great].ToString(CultureInfo.InvariantCulture))
+            };
 
-            playInfo.Add(GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"));
-            playInfo.Add(GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)")));
-            playInfo.Add(GetAttribute("Misses", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture)));
-            playInfo.Add(GetAttribute("Goods", scoreInfo.Statistics[HitResult.Good].ToString(CultureInfo.InvariantCulture)));
-            playInfo.Add(GetAttribute("Greats", scoreInfo.Statistics[HitResult.Great].ToString(CultureInfo.InvariantCulture)));
-
-            return String.Join("\n", playInfo);
+            return string.Join("\n", playInfo);
         }
     }
 }


### PR DESCRIPTION
- Add `--json` arg for simulate command
- Refactor simulate command to use `OutputDocument` rather than `Console.WriteLine`

The json could definitely be formatted better (not using floats for all numbers, mods as bitmask, etc...) but that's a side effect of trying to keep it as close to the regular output as possible.
The purpose of this is mainly to make it easier for other code to consume the output without unnecessary parsing.

Example
```sh
$ dotnet run -- simulate osu "D:\beatmaps\546514" --json
{
  "Beatmap": "Printemps - Eien Friends (Sakaue Nachi) [Friends]",
  "Accuracy": 72.90779547992979,
  "Combo": 1599.0,
  "Great": 1230.0,
  "Good": 0.0,
  "Meh": 0.0,
  "Miss": 0.0,
  "Mods": "None",
  "Aim": 84.74871684189024,
  "Speed": 42.877486554927245,
  "OD": 7.833333333333333,
  "AR": 9.0,
  "Max Combo": 1599.0,
  "pp": 203.99553541963314
}
```