### PR TITLE
Add TotalScore to ScoreInfo on profile command

### DIFF
--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -67,6 +67,7 @@ namespace PerformanceCalculator.Profile
                 var score = new ProcessorScoreDecoder(working).Parse(new ScoreInfo
                 {
                     Ruleset = ruleset.RulesetInfo,
+                    TotalScore = play.score,
                     MaxCombo = play.maxcombo,
                     Mods = mods,
                     Statistics = new Dictionary<HitResult, int>


### PR DESCRIPTION
This one line would fixes wrong mania's pp calculations that fixed to 0 (caused by [this](https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Mania/Difficulty/ManiaPerformanceCalculator.cs#L93))

before)
![image](https://user-images.githubusercontent.com/37479424/97580261-6c274080-1a36-11eb-9da8-d4722f3e92ca.png)
after)
![image](https://user-images.githubusercontent.com/37479424/97580312-79dcc600-1a36-11eb-8979-ab332df9dc7b.png)
