### PR TITLE
Fix osu!catch performance calc in profile command.

### DIFF
--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -72,11 +72,14 @@ namespace PerformanceCalculator.Profile
                     Mods = mods,
                     Statistics = new Dictionary<HitResult, int>
                     {
-                        { HitResult.Perfect, (int)play.countgeki },
+                        { HitResult.Perfect, (Ruleset == 2) ? (int)play.count300 : (int)play.countgeki },
                         { HitResult.Great, (int)play.count300 },
                         { HitResult.Good, (int)play.count100 },
                         { HitResult.Ok, (int)play.countkatu },
                         { HitResult.Meh, (int)play.count50 },
+                        { HitResult.LargeTickHit, (int)play.count100 },
+                        { HitResult.SmallTickHit, (int)play.count50 },
+                        { HitResult.SmallTickMiss, (int)play.countkatu },
                         { HitResult.Miss, (int)play.countmiss }
                     }
                 });

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -14,6 +14,7 @@ using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
+using osu.Game.Scoring.Legacy;
 
 namespace PerformanceCalculator.Profile
 {
@@ -64,25 +65,23 @@ namespace PerformanceCalculator.Profile
 
                 var working = new ProcessorWorkingBeatmap(cachePath, (int)play.beatmap_id);
 
-                var score = new ProcessorScoreDecoder(working).Parse(new ScoreInfo
+                var scoreInfo = new ScoreInfo
                 {
                     Ruleset = ruleset.RulesetInfo,
                     TotalScore = play.score,
                     MaxCombo = play.maxcombo,
                     Mods = mods,
-                    Statistics = new Dictionary<HitResult, int>
-                    {
-                        { HitResult.Perfect, (int)play.countgeki },
-                        { HitResult.Great, (int)play.count300 },
-                        { HitResult.Good, (int)play.count100 },
-                        { HitResult.Ok, (int)play.countkatu },
-                        { HitResult.Meh, (int)play.count50 },
-                        { HitResult.LargeTickHit, (int)play.count100 },
-                        { HitResult.SmallTickHit, (int)play.count50 },
-                        { HitResult.SmallTickMiss, (int)play.countkatu },
-                        { HitResult.Miss, (int)play.countmiss }
-                    }
-                });
+                    Statistics = new Dictionary<HitResult, int>()
+                };
+
+                scoreInfo.SetCount300((int)play.count300);
+                scoreInfo.SetCountGeki((int)play.countgeki);
+                scoreInfo.SetCount100((int)play.count100);
+                scoreInfo.SetCountKatu((int)play.countkatu);
+                scoreInfo.SetCount50((int)play.count50);
+                scoreInfo.SetCountMiss((int)play.countmiss);
+
+                var score = new ProcessorScoreDecoder(working).Parse(scoreInfo);
 
                 var thisPlay = new UserPlayInfo
                 {

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -72,7 +72,7 @@ namespace PerformanceCalculator.Profile
                     Mods = mods,
                     Statistics = new Dictionary<HitResult, int>
                     {
-                        { HitResult.Perfect, (Ruleset == 2) ? (int)play.count300 : (int)play.countgeki },
+                        { HitResult.Perfect, (int)play.countgeki },
                         { HitResult.Great, (int)play.count300 },
                         { HitResult.Good, (int)play.count100 },
                         { HitResult.Ok, (int)play.countkatu },


### PR DESCRIPTION
¯\_(ツ)_/¯
[CatchPerformanceCalculator.cs](https://github.com/ppy/osu/blob/dd7c3dbc5be06743d00ef3a95b450ef23819194b/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs) additionally requires LargeTickHit, SmallTickHit, SmallTickMiss
![image](https://user-images.githubusercontent.com/37479424/98612817-4f451400-2338-11eb-9eb2-91a64bf15fd1.png)

tested this pr's branch with osu!, osu!taiko, osu!catch but only osu!mania is incorrect [(mentioned this here)](https://twitter.com/ilsubyeega/status/1325825555447513089)
