### PR TITLE
Update osu! submodule

### DIFF
--- a/PerformanceCalculator/Performance/PerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/PerformanceCommand.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -38,7 +39,11 @@ namespace PerformanceCalculator.Performance
 
                 // Convert + process beatmap
                 var categoryAttribs = new Dictionary<string, double>();
-                double pp = score.ScoreInfo.Ruleset.CreateInstance().CreatePerformanceCalculator(workingBeatmap, score.ScoreInfo).Calculate(categoryAttribs);
+
+                var performanceCalculator = score.ScoreInfo.Ruleset.CreateInstance().CreatePerformanceCalculator(workingBeatmap, score.ScoreInfo);
+                Trace.Assert(performanceCalculator != null);
+
+                double pp = performanceCalculator.Calculate(categoryAttribs);
 
                 Console.WriteLine(f);
                 writeAttribute("Player", score.ScoreInfo.User.Username);

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Alba.CsConsoleFormat;
@@ -83,10 +84,13 @@ namespace PerformanceCalculator.Profile
 
                 var score = new ProcessorScoreDecoder(working).Parse(scoreInfo);
 
+                var performanceCalculator = ruleset.CreatePerformanceCalculator(working, score.ScoreInfo);
+                Trace.Assert(performanceCalculator != null);
+
                 var thisPlay = new UserPlayInfo
                 {
                     Beatmap = working.BeatmapInfo,
-                    LocalPP = ruleset.CreatePerformanceCalculator(working, score.ScoreInfo).Calculate(),
+                    LocalPP = performanceCalculator.Calculate(),
                     LivePP = play.pp,
                     Mods = mods.Length > 0 ? mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}") : "None"
                 };

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -90,7 +90,7 @@ namespace PerformanceCalculator.Simulate
             return new Dictionary<HitResult, int>
             {
                 { HitResult.Great, countGreat },
-                { HitResult.Good, countGood ?? 0 },
+                { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
                 { HitResult.Miss, countMiss }
             };
@@ -99,7 +99,7 @@ namespace PerformanceCalculator.Simulate
         protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
         {
             var countGreat = statistics[HitResult.Great];
-            var countGood = statistics[HitResult.Good];
+            var countGood = statistics[HitResult.Ok];
             var countMeh = statistics[HitResult.Meh];
             var countMiss = statistics[HitResult.Miss];
             var total = countGreat + countGood + countMeh + countMiss;

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -79,7 +80,11 @@ namespace PerformanceCalculator.Simulate
             };
 
             var categoryAttribs = new Dictionary<string, double>();
-            double pp = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo).Calculate(categoryAttribs);
+
+            var performanceCalculator = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo);
+            Trace.Assert(performanceCalculator != null);
+
+            double pp = performanceCalculator.Calculate(categoryAttribs);
 
             if (OutputJson)
             {

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -78,7 +78,7 @@ namespace PerformanceCalculator.Simulate
             return new Dictionary<HitResult, int>
             {
                 { HitResult.Great, countGreat },
-                { HitResult.Good, (int)countGood },
+                { HitResult.Ok, (int)countGood },
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, countMiss }
             };
@@ -87,7 +87,7 @@ namespace PerformanceCalculator.Simulate
         protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
         {
             var countGreat = statistics[HitResult.Great];
-            var countGood = statistics[HitResult.Good];
+            var countGood = statistics[HitResult.Ok];
             var countMiss = statistics[HitResult.Miss];
             var total = countGreat + countGood + countMiss;
 
@@ -100,9 +100,9 @@ namespace PerformanceCalculator.Simulate
             {
                 GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"),
                 GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)")),
-                GetAttribute("Misses", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture)),
-                GetAttribute("Goods", scoreInfo.Statistics[HitResult.Good].ToString(CultureInfo.InvariantCulture)),
-                GetAttribute("Greats", scoreInfo.Statistics[HitResult.Great].ToString(CultureInfo.InvariantCulture))
+                GetAttribute("Miss", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture)),
+                GetAttribute("Ok", scoreInfo.Statistics[HitResult.Ok].ToString(CultureInfo.InvariantCulture)),
+                GetAttribute("Great", scoreInfo.Statistics[HitResult.Great].ToString(CultureInfo.InvariantCulture))
             };
 
             return string.Join("\n", playInfo);


### PR DESCRIPTION
As the submodule's last update was at https://github.com/ppy/osu/commit/dd7c3dbc5be06743d00ef3a95b450ef23819194b, it did not include the scoring unification efforts from https://github.com/ppy/osu/pull/10288, so a few updates to the `simulate` subcommand were required to restore correctness of calculations.