### PR TITLE
Change Perfect to Great at CatchSimulateCommand

### DIFF
--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -83,7 +83,7 @@ namespace PerformanceCalculator.Simulate
 
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Perfect, countFruits },
+                { HitResult.Great, countFruits },
                 { HitResult.LargeTickHit, countDroplets },
                 { HitResult.SmallTickHit, countTinyDroplets },
                 { HitResult.SmallTickMiss, countTinyMisses },
@@ -93,7 +93,7 @@ namespace PerformanceCalculator.Simulate
 
         protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
         {
-            double hits = statistics[HitResult.Perfect] + statistics[HitResult.LargeTickHit] + statistics[HitResult.SmallTickHit];
+            double hits = statistics[HitResult.Great] + statistics[HitResult.LargeTickHit] + statistics[HitResult.SmallTickHit];
             double total = hits + statistics[HitResult.Miss] + statistics[HitResult.SmallTickMiss];
 
             return hits / total;


### PR DESCRIPTION
since newer version uses Great instead of Perfect
source: https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Catch/Difficulty/CatchPerformanceCalculator.cs