### PR TITLE
Add cache directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,4 @@ __pycache__/
 Staging/
 
 inspectcodereport.xml
+PerformanceCalculator/cache/


### PR DESCRIPTION
When running via `dotnet run -- ...`, beatmaps are stored in the `PerformanceCalculator/cache` directory.