### PR TITLE
Fix non-difficulty-adjustment-mods being removed from pp calculation

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -105,7 +105,7 @@ namespace PerformanceCalculator.Difficulty
         {
             // Get the ruleset
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.RulesetID);
-            var attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(getMods(ruleset).ToArray());
+            var attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, getMods(ruleset).ToArray()));
 
             var result = new Result
             {

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -47,8 +47,17 @@ namespace PerformanceCalculator
         /// </summary>
         public static Mod[] TrimNonDifficultyAdjustmentMods(Ruleset ruleset, Mod[] mods)
         {
+            var beatmap = new EmptyWorkingBeatmap
+            {
+                BeatmapInfo =
+                {
+                    Ruleset = ruleset.RulesetInfo,
+                    BaseDifficulty = new BeatmapDifficulty()
+                }
+            };
+
             var difficultyAdjustmentMods = ModUtils.FlattenMods(
-                                                       ruleset.CreateDifficultyCalculator(new EmptyWorkingBeatmap()).CreateDifficultyAdjustmentModCombinations())
+                                                       ruleset.CreateDifficultyCalculator(beatmap).CreateDifficultyAdjustmentModCombinations())
                                                    .Select(m => m.GetType())
                                                    .Distinct()
                                                    .ToHashSet();

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -2,11 +2,19 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.IO;
+using System.Linq;
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics.Textures;
+using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Taiko;
+using osu.Game.Skinning;
+using osu.Game.Utils;
 
 namespace PerformanceCalculator
 {
@@ -31,6 +39,39 @@ namespace PerformanceCalculator
                 case 3:
                     return new ManiaRuleset();
             }
+        }
+
+        /// <summary>
+        /// Trims all mods from a given <see cref="Mod"/> array which do not adjust difficulty.
+        /// This is used to match osu!stable/osu!web calculations for the time being, until such a point that these mods do get considered.
+        /// </summary>
+        public static Mod[] TrimNonDifficultyAdjustmentMods(Ruleset ruleset, Mod[] mods)
+        {
+            var difficultyAdjustmentMods = ModUtils.FlattenMods(
+                                                       ruleset.CreateDifficultyCalculator(new EmptyWorkingBeatmap()).CreateDifficultyAdjustmentModCombinations())
+                                                   .Select(m => m.GetType())
+                                                   .Distinct()
+                                                   .ToHashSet();
+
+            return mods.Where(m => difficultyAdjustmentMods.Contains(m.GetType())).ToArray();
+        }
+
+        private class EmptyWorkingBeatmap : WorkingBeatmap
+        {
+            public EmptyWorkingBeatmap()
+                : base(new BeatmapInfo(), null)
+            {
+            }
+
+            protected override IBeatmap GetBeatmap() => throw new NotImplementedException();
+
+            protected override Texture GetBackground() => throw new NotImplementedException();
+
+            protected override Track GetBeatmapTrack() => throw new NotImplementedException();
+
+            protected override ISkin GetSkin() => throw new NotImplementedException();
+
+            public override Stream GetStream(string storagePath) => throw new NotImplementedException();
         }
     }
 }

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -53,6 +53,10 @@ namespace PerformanceCalculator
                                                    .Distinct()
                                                    .ToHashSet();
 
+            // Special case for DT/NC.
+            if (mods.Any(m => m is ModDoubleTime))
+                difficultyAdjustmentMods.Add(ruleset.GetAllMods().Single(m => m is ModNightcore).GetType());
+
             return mods.Where(m => difficultyAdjustmentMods.Contains(m.GetType())).ToArray();
         }
 

--- a/PerformanceCalculator/Performance/PerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/PerformanceCommand.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -37,12 +36,12 @@ namespace PerformanceCalculator.Performance
                 using (var stream = File.OpenRead(f))
                     score = scoreParser.Parse(stream);
 
-                // Convert + process beatmap
+                var ruleset = score.ScoreInfo.Ruleset.CreateInstance();
+                var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
+                var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, score.ScoreInfo.Mods).ToArray());
+                var performanceCalculator = score.ScoreInfo.Ruleset.CreateInstance().CreatePerformanceCalculator(difficultyAttributes, score.ScoreInfo);
+
                 var categoryAttribs = new Dictionary<string, double>();
-
-                var performanceCalculator = score.ScoreInfo.Ruleset.CreateInstance().CreatePerformanceCalculator(workingBeatmap, score.ScoreInfo);
-                Trace.Assert(performanceCalculator != null);
-
                 double pp = performanceCalculator.Calculate(categoryAttribs);
 
                 Console.WriteLine(f);

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -103,11 +102,11 @@ namespace PerformanceCalculator.Simulate
                 RulesetID = Ruleset.RulesetInfo.ID ?? 0
             };
 
+            var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
+            var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, scoreInfo.Mods).ToArray());
+            var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, scoreInfo);
+
             var categoryAttribs = new Dictionary<string, double>();
-
-            var performanceCalculator = ruleset.CreatePerformanceCalculator(workingBeatmap, scoreInfo);
-            Trace.Assert(performanceCalculator != null);
-
             double pp = performanceCalculator.Calculate(categoryAttribs);
 
             if (OutputJson)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-tools/issues/112

Manually calculating difficulty via `DifficultyCalculator` in order to use the new `LegacyHelper.TrimNonDifficultyAdjustmentMods()` function to trim extra mods, then passing the resultant difficulty attributes into the `PerformanceCalculator`s.

`performance` command tested using https://osu.ppy.sh/scores/osu/3735818682 :
```
Player         : mrekk
Mods           : DT, HD, CL
Aim            : 411.2379017594664
Speed          : 525.196717108101
Accuracy       : 164.98011203869308
OD             : 10.444444444444445
AR             : 10.466666666666667
Max Combo      : 2275
pp             : 1126.6058989316116
```

`profile` command tested using https://osu.ppy.sh/users/7562902/osu : [osu.txt](https://github.com/ppy/osu-tools/files/6943139/osu.txt)
`profile` command tested using https://osu.ppy.sh/users/8741695/taiko : [taiko.txt](https://github.com/ppy/osu-tools/files/6943140/taiko.txt)
`profile` command tested using https://osu.ppy.sh/users/4158549/fruits : [catch.txt](https://github.com/ppy/osu-tools/files/6943141/catch.txt)
`profile` command tested using https://osu.ppy.sh/users/10137852/mania : [mania.txt](https://github.com/ppy/osu-tools/files/6945223/mania.txt)



`simulate` and `difficulty` are untested but presumed to work due to the above. Note that my previous changes only adjusted the `profile` command, but these changes should be applied to all commands.