### PR TITLE
Use `{Get -> Create}AllMods()` in line with game changes

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -164,7 +164,7 @@ namespace PerformanceCalculator.Difficulty
             if (Mods == null)
                 return mods;
 
-            var availableMods = ruleset.GetAllMods().ToList();
+            var availableMods = ruleset.CreateAllMods().ToList();
 
             foreach (var modString in Mods)
             {

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -64,7 +64,7 @@ namespace PerformanceCalculator
 
             // Special case for DT/NC.
             if (mods.Any(m => m is ModDoubleTime))
-                difficultyAdjustmentMods.Add(ruleset.GetAllMods().Single(m => m is ModNightcore).GetType());
+                difficultyAdjustmentMods.Add(ruleset.CreateAllMods().Single(m => m is ModNightcore).GetType());
 
             return mods.Where(m => difficultyAdjustmentMods.Contains(m.GetType())).ToArray();
         }

--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Alba.CsConsoleFormat" Version="1.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="ppy.osu.Game" Version="2021.828.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.828.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.828.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.828.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.828.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.916.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.916.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.916.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.916.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.916.0" />
   </ItemGroup>
 </Project>

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -160,7 +160,7 @@ namespace PerformanceCalculator.Simulate
             if (Mods == null)
                 return mods;
 
-            var availableMods = ruleset.GetAllMods().ToList();
+            var availableMods = ruleset.CreateAllMods().ToList();
 
             foreach (var modString in Mods)
             {


### PR DESCRIPTION
 - [x] Depends on game bump

Follow up item after https://github.com/ppy/osu/pull/14696/, as `GetAllMods()` was removed in favour of two alternate methods.

Using `AllMods` instead is not viable yet, as that returns `IMod`s, and the entire structure of diffcalc relies on receiving raw `Mod`s, so migrating to that is not an insignificant effort. This change should have no performance impact as `CreateAllMods()` has the exact same implementation that `GetAllMods()` used to have.
