### PR TITLE
Reordered JSON attributes in SimulateCommand

### DIFF
--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -94,10 +94,10 @@ namespace PerformanceCalculator.Simulate
                     { "Beatmap", workingBeatmap.BeatmapInfo.ToString() }
                 };
 
-                o["ScoreStatistics"] = new JObject();
+                o["Statistics"] = new JObject();
 
                 foreach (var info in getPlayValues(scoreInfo, beatmap))
-                    o["ScoreStatistics"][info.Key] = info.Value;
+                    o["Statistics"][info.Key] = info.Value;
 
                 foreach (var kvp in categoryAttribs)
                     o[kvp.Key] = kvp.Value;


### PR DESCRIPTION
This fixes issue #124 

It changes the behavior of the simulate command when outputing json using `--json` flag.

Command:
```bash
dotnet run --project PerformanceCalculator.csproj --configuration Release -- simulate osu map.osu -m:Hd -m:HR -G:5 --json
```

Before:
```json
{
  "Beatmap": "xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]",
  "Accuracy": 222.7765006385657,
  "Combo": 2385.0,
  "Great": 1978.0,
  "Ok": 5.0,
  "Meh": 0.0,
  "Miss": 0.0,
  "Mods": "HD, HR",
  "Aim": 282.549316567955,
  "Speed": 382.89578323239095,
  "Flashlight": 0.0,
  "OD": 10.0,
  "AR": 10.0,
  "Max Combo": 2385.0,
  "pp": 902.472286786258
}
```

After:

```json
{
  "Beatmap": "xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]",
  "ScoreStatistics": {
    "Accuracy": 99.83190452176837,
    "Combo": 2385.0,
    "Great": 1978.0,
    "Ok": 5.0,
    "Meh": 0.0,
    "Miss": 0.0
  },
  "Aim": 282.549316567955,
  "Speed": 382.89578323239095,
  "Accuracy": 222.7765006385657,
  "Flashlight": 0.0,
  "OD": 10.0,
  "AR": 10.0,
  "Max Combo": 2385.0,
  "Mods": "HD, HR",
  "pp": 902.472286786258
}
```