### PR TITLE
Additions to simulate and difficulty commands regarding star rating

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -170,6 +170,7 @@ namespace PerformanceCalculator.Difficulty
                     {
                         ("aim rating", osu.AimStrain.ToString("N2")),
                         ("speed rating", osu.SpeedStrain.ToString("N2")),
+                        ("slider factor", osu.SliderFactor.ToString("N2")),
                         ("max combo", osu.MaxCombo),
                         ("approach rate", osu.ApproachRate.ToString("N2")),
                         ("overall difficulty", osu.OverallDifficulty.ToString("N2")),

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -84,9 +84,10 @@ namespace PerformanceCalculator.Difficulty
                             ["Ruleset"] = LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName,
                             ["Beatmap"] = result.Beatmap,
                             ["Beatmap ID"] = result.BeatmapId,
-                            ["Star rating"] = Convert.ToDouble(result.Stars),
-                            ["Attributes"] = new JObject()
+                            ["Star rating"] = Convert.ToDouble(result.Stars)
                         };
+
+                        jsonResult["Attributes"] = new JObject();
 
                         foreach (var attribute in result.AttributeData)
                             jsonResult["Attributes"][attribute.name] = Convert.ToDouble(attribute.value);

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -83,7 +83,7 @@ namespace PerformanceCalculator.Difficulty
                         {
                             ["Ruleset"] = LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName,
                             ["Beatmap"] = result.Beatmap,
-                            ["Beatmap ID"] = Convert.ToDouble(result.BeatmapId),
+                            ["Beatmap ID"] = result.BeatmapId,
                             ["Star rating"] = Convert.ToDouble(result.Stars),
                             ["Attributes"] = new JObject()
                         };
@@ -157,7 +157,7 @@ namespace PerformanceCalculator.Difficulty
             var result = new Result
             {
                 RulesetId = ruleset.RulesetInfo.ID ?? 0,
-                BeatmapId = beatmap.BeatmapInfo.OnlineID.ToString(),
+                BeatmapId = beatmap.BeatmapInfo.OnlineID ?? 0,
                 Beatmap = beatmap.BeatmapInfo.ToString(),
                 Stars = attributes.StarRating.ToString("N2")
             };
@@ -235,7 +235,7 @@ namespace PerformanceCalculator.Difficulty
         private struct Result
         {
             public int RulesetId;
-            public string BeatmapId;
+            public int BeatmapId;
             public string Beatmap;
             public string Stars;
             public List<(string name, object value)> AttributeData;

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -135,6 +135,9 @@ namespace PerformanceCalculator.Difficulty
                 case TaikoDifficultyAttributes taiko:
                     result.AttributeData = new List<(string, object)>
                     {
+                        ("rhythm strain", taiko.RhythmStrain.ToString("N2")),
+                        ("colour strain", taiko.ColourStrain.ToString("N2")),
+                        ("stamina strain", taiko.StaminaStrain.ToString("N2")),
                         ("hit window", taiko.GreatHitWindow.ToString("N2")),
                         ("max combo", taiko.MaxCombo)
                     };

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -75,11 +75,11 @@ namespace PerformanceCalculator.Difficulty
 
                 if (results.Any())
                 {
-                    var json_results = new JArray();
+                    var jsonResults = new JArray();
 
                     foreach (var result in results)
                     {
-                        var json_result = new JObject
+                        var jsonResult = new JObject
                         {
                             ["Ruleset"] = LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName,
                             ["Beatmap"] = result.Beatmap,
@@ -89,12 +89,12 @@ namespace PerformanceCalculator.Difficulty
                         };
 
                         foreach (var attribute in result.AttributeData)
-                            json_result["Attributes"][attribute.name] = Convert.ToDouble(attribute.value.ToString());
+                            jsonResult["Attributes"][attribute.name] = Convert.ToDouble(attribute.value);
 
-                        json_results.Add(json_result);
+                        jsonResults.Add(jsonResult);
                     }
 
-                    o["Results"] = json_results;
+                    o["Results"] = jsonResults;
                 }
 
                 string json = o.ToString();

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -81,10 +81,10 @@ namespace PerformanceCalculator.Difficulty
                     {
                         var jsonResult = new JObject
                         {
-                            ["Ruleset"] = LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName,
-                            ["Beatmap"] = result.Beatmap,
-                            ["Beatmap ID"] = result.BeatmapId,
-                            ["Star rating"] = Convert.ToDouble(result.Stars)
+                            { "Ruleset", LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName },
+                            { "Beatmap", result.Beatmap },
+                            { "Beatmap ID", result.BeatmapId },
+                            { "Star rating", Convert.ToDouble(result.Stars) }
                         };
 
                         jsonResult["Attributes"] = new JObject();

--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -6,7 +6,9 @@ using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Catch.Difficulty;
 using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using System;
@@ -82,6 +84,16 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.SmallTickHit, countTinyDroplets },
                 { HitResult.SmallTickMiss, countTinyMisses },
                 { HitResult.Miss, countMiss }
+            };
+        }
+
+        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
+        {
+            CatchDifficultyAttributes catchDifficultyAttributes = (CatchDifficultyAttributes)difficultyAttributes;
+
+            return new Dictionary<string, double>
+            {
+                { "Star rating", catchDifficultyAttributes.StarRating }
             };
         }
 

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -9,7 +9,9 @@ using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -73,6 +75,16 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.Good, 0 },
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, 0 }
+            };
+        }
+
+        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
+        {
+            ManiaDifficultyAttributes maniaDifficultyAttributes = (ManiaDifficultyAttributes)difficultyAttributes;
+
+            return new Dictionary<string, double>
+            {
+                { "Star rating", maniaDifficultyAttributes.StarRating }
             };
         }
 

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -101,7 +101,8 @@ namespace PerformanceCalculator.Simulate
             {
                 { "Star rating", osuDifficultyAttributes.StarRating },
                 { "Aim strain", osuDifficultyAttributes.AimStrain },
-                { "Speed strain", osuDifficultyAttributes.SpeedStrain }
+                { "Speed strain", osuDifficultyAttributes.SpeedStrain },
+                { "Slider factor", osuDifficultyAttributes.SliderFactor }
             };
 
             if (GetMods(Ruleset).Any(m => m is ModFlashlight))

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -9,7 +9,10 @@ using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Difficulty;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -88,6 +91,23 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.Meh, countMeh ?? 0 },
                 { HitResult.Miss, countMiss }
             };
+        }
+
+        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
+        {
+            OsuDifficultyAttributes osuDifficultyAttributes = (OsuDifficultyAttributes)difficultyAttributes;
+
+            Dictionary<string, double> difficultyAttributesSkills = new Dictionary<string, double>
+            {
+                { "Star rating", osuDifficultyAttributes.StarRating },
+                { "Aim strain", osuDifficultyAttributes.AimStrain },
+                { "Speed strain", osuDifficultyAttributes.SpeedStrain }
+            };
+
+            if (GetMods(Ruleset).Any(m => m is ModFlashlight))
+                difficultyAttributesSkills.Add("Flashlight rating", osuDifficultyAttributes.FlashlightRating);
+
+            return difficultyAttributesSkills;
         }
 
         protected override double GetAccuracy(Dictionary<HitResult, int> statistics)

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -13,6 +13,7 @@ using McMaster.Extensions.CommandLineUtils;
 using Newtonsoft.Json.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -106,6 +107,11 @@ namespace PerformanceCalculator.Simulate
 
                 o["pp"] = pp;
 
+                o["Difficulty"] = new JObject();
+
+                foreach (var kvp in GetDifficultyAttributesSkills(difficultyAttributes))
+                    o["Difficulty"][kvp.Key] = kvp.Value;
+
                 string json = o.ToString();
 
                 Console.Write(json);
@@ -126,6 +132,9 @@ namespace PerformanceCalculator.Simulate
                     : "None")), "\n");
 
                 foreach (var kvp in categoryAttribs)
+                    document.Children.Add(new Span(GetAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture))), "\n");
+
+                foreach (var kvp in GetDifficultyAttributesSkills(difficultyAttributes))
                     document.Children.Add(new Span(GetAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture))), "\n");
 
                 document.Children.Add(new Span(GetAttribute("pp", pp.ToString(CultureInfo.InvariantCulture))));
@@ -175,6 +184,8 @@ namespace PerformanceCalculator.Simulate
         protected abstract int GetMaxCombo(IBeatmap beatmap);
 
         protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood);
+
+        protected abstract Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes);
 
         protected virtual double GetAccuracy(Dictionary<HitResult, int> statistics) => 0;
 

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -9,8 +9,10 @@ using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
+using osu.Game.Rulesets.Taiko.Difficulty;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Scoring;
 
@@ -75,6 +77,19 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.Ok, (int)countGood },
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, countMiss }
+            };
+        }
+
+        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
+        {
+            TaikoDifficultyAttributes taikoDifficultyAttributes = (TaikoDifficultyAttributes)difficultyAttributes;
+
+            return new Dictionary<string, double>
+            {
+                { "Star rating", taikoDifficultyAttributes.StarRating },
+                { "Rhythm strain", taikoDifficultyAttributes.RhythmStrain },
+                { "Colour strain", taikoDifficultyAttributes.ColourStrain },
+                { "Stamina strain", taikoDifficultyAttributes.StaminaStrain }
             };
         }
 


### PR DESCRIPTION
The simulate command now shows the star rating. People seem to be interested in inspecting the individual difficulty attributes that are tied into star rating, so those are shown as well. To make this possible each specialisation of the simulate command now needs to provide a collection of these difficulty attributes. In the json output the star rating and other attributes are grouped under the category 'Difficulty'.

Included additional difficulty attributes in the difficulty command for the taiko game mode.

Added an option for the difficulty command to output as machine readable json. To make this possible the variable 'Beatmap' in DifficultyCommand.Result has been split into two variables.

The commands difficulty and simulate have been tested using several maps, game modes and mod combinations (including FL). Other commands are assumed to work since they haven't been touched.