### PR TITLE
Improve output of `difficulty` and `simulate` commands

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -170,6 +170,7 @@ namespace PerformanceCalculator.Difficulty
                     {
                         ("aim rating", osu.AimStrain.ToString("N2")),
                         ("speed rating", osu.SpeedStrain.ToString("N2")),
+                        ("slider factor", osu.SliderFactor.ToString("N2")),
                         ("max combo", osu.MaxCombo),
                         ("approach rate", osu.ApproachRate.ToString("N2")),
                         ("overall difficulty", osu.OverallDifficulty.ToString("N2")),

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -84,9 +84,10 @@ namespace PerformanceCalculator.Difficulty
                             ["Ruleset"] = LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName,
                             ["Beatmap"] = result.Beatmap,
                             ["Beatmap ID"] = result.BeatmapId,
-                            ["Star rating"] = Convert.ToDouble(result.Stars),
-                            ["Attributes"] = new JObject()
+                            ["Star rating"] = Convert.ToDouble(result.Stars)
                         };
+
+                        jsonResult["Attributes"] = new JObject();
 
                         foreach (var attribute in result.AttributeData)
                             jsonResult["Attributes"][attribute.name] = Convert.ToDouble(attribute.value);

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -83,7 +83,7 @@ namespace PerformanceCalculator.Difficulty
                         {
                             ["Ruleset"] = LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName,
                             ["Beatmap"] = result.Beatmap,
-                            ["Beatmap ID"] = Convert.ToDouble(result.BeatmapId),
+                            ["Beatmap ID"] = result.BeatmapId,
                             ["Star rating"] = Convert.ToDouble(result.Stars),
                             ["Attributes"] = new JObject()
                         };
@@ -157,7 +157,7 @@ namespace PerformanceCalculator.Difficulty
             var result = new Result
             {
                 RulesetId = ruleset.RulesetInfo.ID ?? 0,
-                BeatmapId = beatmap.BeatmapInfo.OnlineID.ToString(),
+                BeatmapId = beatmap.BeatmapInfo.OnlineID ?? 0,
                 Beatmap = beatmap.BeatmapInfo.ToString(),
                 Stars = attributes.StarRating.ToString("N2")
             };
@@ -235,7 +235,7 @@ namespace PerformanceCalculator.Difficulty
         private struct Result
         {
             public int RulesetId;
-            public string BeatmapId;
+            public int BeatmapId;
             public string Beatmap;
             public string Stars;
             public List<(string name, object value)> AttributeData;

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -85,15 +85,14 @@ namespace PerformanceCalculator.Difficulty
                 foreach (var group in resultSet.Results.GroupBy(r => r.RulesetId))
                 {
                     var ruleset = LegacyHelper.GetRulesetFromLegacyID(group.First().RulesetId);
-                    document.Children.Add(new Span($"Ruleset: {ruleset.ShortName}"), "\n");
+                    document.Children.Add(new Span($"ruleset: {ruleset.ShortName}"), "\n");
 
                     Grid grid = new Grid();
                     bool firstResult = true;
 
                     foreach (var result in group)
                     {
-                        var attributeValues = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(result.Attributes))
-                                              ?? new Dictionary<string, object>();
+                        var attributeValues = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(result.Attributes)) ?? new Dictionary<string, object>();
 
                         // Headers
                         if (firstResult)

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -135,6 +135,9 @@ namespace PerformanceCalculator.Difficulty
                 case TaikoDifficultyAttributes taiko:
                     result.AttributeData = new List<(string, object)>
                     {
+                        ("rhythm strain", taiko.RhythmStrain.ToString("N2")),
+                        ("colour strain", taiko.ColourStrain.ToString("N2")),
+                        ("stamina strain", taiko.StaminaStrain.ToString("N2")),
                         ("hit window", taiko.GreatHitWindow.ToString("N2")),
                         ("max combo", taiko.MaxCombo)
                     };

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -75,11 +75,11 @@ namespace PerformanceCalculator.Difficulty
 
                 if (results.Any())
                 {
-                    var json_results = new JArray();
+                    var jsonResults = new JArray();
 
                     foreach (var result in results)
                     {
-                        var json_result = new JObject
+                        var jsonResult = new JObject
                         {
                             ["Ruleset"] = LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName,
                             ["Beatmap"] = result.Beatmap,
@@ -89,12 +89,12 @@ namespace PerformanceCalculator.Difficulty
                         };
 
                         foreach (var attribute in result.AttributeData)
-                            json_result["Attributes"][attribute.name] = Convert.ToDouble(attribute.value.ToString());
+                            jsonResult["Attributes"][attribute.name] = Convert.ToDouble(attribute.value);
 
-                        json_results.Add(json_result);
+                        jsonResults.Add(jsonResult);
                     }
 
-                    o["Results"] = json_results;
+                    o["Results"] = jsonResults;
                 }
 
                 string json = o.ToString();

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -81,10 +81,10 @@ namespace PerformanceCalculator.Difficulty
                     {
                         var jsonResult = new JObject
                         {
-                            ["Ruleset"] = LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName,
-                            ["Beatmap"] = result.Beatmap,
-                            ["Beatmap ID"] = result.BeatmapId,
-                            ["Star rating"] = Convert.ToDouble(result.Stars)
+                            { "Ruleset", LegacyHelper.GetRulesetFromLegacyID(result.RulesetId).ShortName },
+                            { "Beatmap", result.Beatmap },
+                            { "Beatmap ID", result.BeatmapId },
+                            { "Star rating", Convert.ToDouble(result.Stars) }
                         };
 
                         jsonResult["Attributes"] = new JObject();

--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Alba.CsConsoleFormat" Version="1.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="ppy.osu.Game" Version="2021.1113.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.1113.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.1113.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.1113.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.1113.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2021.1120.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.1120.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.1120.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.1120.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.1120.0" />
   </ItemGroup>
 </Project>

--- a/PerformanceCalculator/ProcessorScoreDecoder.cs
+++ b/PerformanceCalculator/ProcessorScoreDecoder.cs
@@ -23,7 +23,7 @@ namespace PerformanceCalculator
         public Score Parse(ScoreInfo scoreInfo)
         {
             var score = new Score { ScoreInfo = scoreInfo };
-            CalculateAccuracy(score.ScoreInfo);
+            PopulateAccuracy(score.ScoreInfo);
             return score;
         }
 

--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -6,14 +6,10 @@ using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
-using osu.Game.Rulesets.Catch.Difficulty;
 using osu.Game.Rulesets.Catch.Objects;
-using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Scoring;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 
 namespace PerformanceCalculator.Simulate
@@ -87,38 +83,12 @@ namespace PerformanceCalculator.Simulate
             };
         }
 
-        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
-        {
-            CatchDifficultyAttributes catchDifficultyAttributes = (CatchDifficultyAttributes)difficultyAttributes;
-
-            return new Dictionary<string, double>
-            {
-                { "Star rating", catchDifficultyAttributes.StarRating }
-            };
-        }
-
         protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
         {
             double hits = statistics[HitResult.Great] + statistics[HitResult.LargeTickHit] + statistics[HitResult.SmallTickHit];
             double total = hits + statistics[HitResult.Miss] + statistics[HitResult.SmallTickMiss];
 
             return hits / total;
-        }
-
-        protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
-        {
-            var playInfo = new List<string>
-            {
-                GetAttribute("ApproachRate", FormattableString.Invariant($"{beatmap.BeatmapInfo.BaseDifficulty.ApproachRate}")),
-                GetAttribute("MaxCombo", FormattableString.Invariant($"{scoreInfo.MaxCombo}"))
-            };
-
-            foreach (var statistic in scoreInfo.Statistics)
-            {
-                playInfo.Add(GetAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture)));
-            }
-
-            return string.Join("\n", playInfo);
         }
     }
 }

--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -6,7 +6,9 @@ using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
+using osu.Game.Rulesets.Catch.Difficulty;
 using osu.Game.Rulesets.Catch.Objects;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using System;
@@ -82,6 +84,16 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.SmallTickHit, countTinyDroplets },
                 { HitResult.SmallTickMiss, countTinyMisses },
                 { HitResult.Miss, countMiss }
+            };
+        }
+
+        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
+        {
+            CatchDifficultyAttributes catchDifficultyAttributes = (CatchDifficultyAttributes)difficultyAttributes;
+
+            return new Dictionary<string, double>
+            {
+                { "Star rating", catchDifficultyAttributes.StarRating }
             };
         }
 

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -9,7 +9,9 @@ using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -73,6 +75,16 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.Good, 0 },
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, 0 }
+            };
+        }
+
+        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
+        {
+            ManiaDifficultyAttributes maniaDifficultyAttributes = (ManiaDifficultyAttributes)difficultyAttributes;
+
+            return new Dictionary<string, double>
+            {
+                { "Star rating", maniaDifficultyAttributes.StarRating }
             };
         }
 

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -4,17 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mania;
-using osu.Game.Rulesets.Mania.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Scoring;
 
 namespace PerformanceCalculator.Simulate
 {
@@ -76,21 +72,6 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, 0 }
             };
-        }
-
-        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
-        {
-            ManiaDifficultyAttributes maniaDifficultyAttributes = (ManiaDifficultyAttributes)difficultyAttributes;
-
-            return new Dictionary<string, double>
-            {
-                { "Star rating", maniaDifficultyAttributes.StarRating }
-            };
-        }
-
-        protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
-        {
-            return GetAttribute("Score", scoreInfo.TotalScore.ToString(CultureInfo.InvariantCulture));
         }
     }
 }

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -101,7 +101,8 @@ namespace PerformanceCalculator.Simulate
             {
                 { "Star rating", osuDifficultyAttributes.StarRating },
                 { "Aim strain", osuDifficultyAttributes.AimStrain },
-                { "Speed strain", osuDifficultyAttributes.SpeedStrain }
+                { "Speed strain", osuDifficultyAttributes.SpeedStrain },
+                { "Slider factor", osuDifficultyAttributes.SliderFactor }
             };
 
             if (GetMods(Ruleset).Any(m => m is ModFlashlight))

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -9,7 +9,10 @@ using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Difficulty;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -88,6 +91,23 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.Meh, countMeh ?? 0 },
                 { HitResult.Miss, countMiss }
             };
+        }
+
+        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
+        {
+            OsuDifficultyAttributes osuDifficultyAttributes = (OsuDifficultyAttributes)difficultyAttributes;
+
+            Dictionary<string, double> difficultyAttributesSkills = new Dictionary<string, double>
+            {
+                { "Star rating", osuDifficultyAttributes.StarRating },
+                { "Aim strain", osuDifficultyAttributes.AimStrain },
+                { "Speed strain", osuDifficultyAttributes.SpeedStrain }
+            };
+
+            if (GetMods(Ruleset).Any(m => m is ModFlashlight))
+                difficultyAttributesSkills.Add("Flashlight rating", osuDifficultyAttributes.FlashlightRating);
+
+            return difficultyAttributesSkills;
         }
 
         protected override double GetAccuracy(Dictionary<HitResult, int> statistics)

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -3,19 +3,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Difficulty;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Osu.Difficulty;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
-using osu.Game.Scoring;
 
 namespace PerformanceCalculator.Simulate
 {
@@ -93,24 +88,6 @@ namespace PerformanceCalculator.Simulate
             };
         }
 
-        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
-        {
-            OsuDifficultyAttributes osuDifficultyAttributes = (OsuDifficultyAttributes)difficultyAttributes;
-
-            Dictionary<string, double> difficultyAttributesSkills = new Dictionary<string, double>
-            {
-                { "Star rating", osuDifficultyAttributes.StarRating },
-                { "Aim strain", osuDifficultyAttributes.AimStrain },
-                { "Speed strain", osuDifficultyAttributes.SpeedStrain },
-                { "Slider factor", osuDifficultyAttributes.SliderFactor }
-            };
-
-            if (GetMods(Ruleset).Any(m => m is ModFlashlight))
-                difficultyAttributesSkills.Add("Flashlight rating", osuDifficultyAttributes.FlashlightRating);
-
-            return difficultyAttributesSkills;
-        }
-
         protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
         {
             var countGreat = statistics[HitResult.Great];
@@ -120,22 +97,6 @@ namespace PerformanceCalculator.Simulate
             var total = countGreat + countGood + countMeh + countMiss;
 
             return (double)((6 * countGreat) + (2 * countGood) + countMeh) / (6 * total);
-        }
-
-        protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
-        {
-            var playInfo = new List<string>
-            {
-                GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"),
-                GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)"))
-            };
-
-            foreach (var statistic in scoreInfo.Statistics)
-            {
-                playInfo.Add(GetAttribute(Enum.GetName(typeof(HitResult), statistic.Key), statistic.Value.ToString(CultureInfo.InvariantCulture)));
-            }
-
-            return string.Join("\n", playInfo);
         }
     }
 }

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -102,7 +102,8 @@ namespace PerformanceCalculator.Simulate
                     Statistics = statistics
                 },
                 Pp = pp,
-                Attributes = difficultyAttributes
+                PerformanceAttributes = categoryAttribs.ToDictionary(k => k.Key.ToLowerInvariant(), k => k.Value),
+                DifficultyAttributes = difficultyAttributes
             };
 
             if (OutputJson)
@@ -129,19 +130,25 @@ namespace PerformanceCalculator.Simulate
 
                 document.Children.Add("---\n");
 
-                // Hit statistics
+                // Hit statistics.
                 foreach (var stat in result.Score.Statistics)
                     document.Children.Add(FormatDocumentLine(stat.Key.ToString().ToLowerInvariant(), stat.Value.ToString(CultureInfo.InvariantCulture)));
 
                 document.Children.Add("---\n");
 
-                // pp.
+                // Performance attributes.
                 document.Children.Add(FormatDocumentLine("pp", result.Pp.ToString("N2", CultureInfo.InvariantCulture)));
+
+                foreach (var attrib in result.PerformanceAttributes)
+                {
+                    // For the time being, we don't have explicitly defined storage for these attributes.
+                    document.Children.Add(FormatDocumentLine(attrib.Key, attrib.Value.ToString("N2")));
+                }
 
                 document.Children.Add("---\n");
 
-                // Difficulty attributes
-                var attributeValues = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(result.Attributes)) ?? new Dictionary<string, object>();
+                // Difficulty attributes.
+                var attributeValues = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(result.DifficultyAttributes)) ?? new Dictionary<string, object>();
                 foreach (var attrib in attributeValues)
                     document.Children.Add(FormatDocumentLine(attrib.Key.Humanize(), $"{attrib.Value:N2}"));
 
@@ -185,8 +192,11 @@ namespace PerformanceCalculator.Simulate
             [JsonProperty("pp")]
             public double Pp { get; set; }
 
+            [JsonProperty("performance_attributes")]
+            public IDictionary<string, double> PerformanceAttributes { get; set; }
+
             [JsonProperty("difficulty_attributes")]
-            public DifficultyAttributes Attributes { get; set; }
+            public DifficultyAttributes DifficultyAttributes { get; set; }
         }
 
         /// <summary>

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -119,11 +119,11 @@ namespace PerformanceCalculator.Simulate
 
                 // Basic score info.
                 document.Children.Add(
-                    FormatDocumentLine("Beatmap", result.Score.Beatmap),
+                    FormatDocumentLine("Beatmap", $"{result.Score.BeatmapId} - {result.Score.Beatmap}"),
                     FormatDocumentLine("Score", result.Score.Score.ToString(CultureInfo.InvariantCulture)),
                     FormatDocumentLine("Accuracy", result.Score.Accuracy.ToString("N2", CultureInfo.InvariantCulture)),
                     FormatDocumentLine("Combo", result.Score.Combo.ToString(CultureInfo.InvariantCulture)),
-                    FormatDocumentLine("Mods", result.Score.Mods.Count > 0 ? result.Score.Mods.Select(m => m.Acronym).Aggregate((c, n) => $"{c}, {n}") : "None")
+                    FormatDocumentLine("Mods", result.Score.Mods.Count > 0 ? result.Score.Mods.Select(m => m.ToString()).Aggregate((c, n) => $"{c}, {n}") : "None")
                 );
 
                 // Hit statistics

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -13,6 +13,7 @@ using McMaster.Extensions.CommandLineUtils;
 using Newtonsoft.Json.Linq;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
@@ -106,6 +107,11 @@ namespace PerformanceCalculator.Simulate
 
                 o["pp"] = pp;
 
+                o["Difficulty"] = new JObject();
+
+                foreach (var kvp in GetDifficultyAttributesSkills(difficultyAttributes))
+                    o["Difficulty"][kvp.Key] = kvp.Value;
+
                 string json = o.ToString();
 
                 Console.Write(json);
@@ -126,6 +132,9 @@ namespace PerformanceCalculator.Simulate
                     : "None")), "\n");
 
                 foreach (var kvp in categoryAttribs)
+                    document.Children.Add(new Span(GetAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture))), "\n");
+
+                foreach (var kvp in GetDifficultyAttributesSkills(difficultyAttributes))
                     document.Children.Add(new Span(GetAttribute(kvp.Key, kvp.Value.ToString(CultureInfo.InvariantCulture))), "\n");
 
                 document.Children.Add(new Span(GetAttribute("pp", pp.ToString(CultureInfo.InvariantCulture))));
@@ -175,6 +184,8 @@ namespace PerformanceCalculator.Simulate
         protected abstract int GetMaxCombo(IBeatmap beatmap);
 
         protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood);
+
+        protected abstract Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes);
 
         protected virtual double GetAccuracy(Dictionary<HitResult, int> statistics) => 0;
 

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -102,7 +102,7 @@ namespace PerformanceCalculator.Simulate
                     Statistics = statistics
                 },
                 Pp = pp,
-                PerformanceAttributes = categoryAttribs.ToDictionary(k => k.Key.ToLowerInvariant(), k => k.Value),
+                PerformanceAttributes = categoryAttribs.ToDictionary(k => k.Key.ToLowerInvariant().Underscore(), k => k.Value),
                 DifficultyAttributes = difficultyAttributes
             };
 
@@ -142,7 +142,7 @@ namespace PerformanceCalculator.Simulate
                 foreach (var attrib in result.PerformanceAttributes)
                 {
                     // For the time being, we don't have explicitly defined storage for these attributes.
-                    document.Children.Add(FormatDocumentLine(attrib.Key, attrib.Value.ToString("N2")));
+                    document.Children.Add(FormatDocumentLine(attrib.Key.Humanize().ToLowerInvariant(), attrib.Value.ToString("N2")));
                 }
 
                 document.Children.Add("---\n");

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -9,8 +9,10 @@ using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
+using osu.Game.Rulesets.Taiko.Difficulty;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Scoring;
 
@@ -75,6 +77,19 @@ namespace PerformanceCalculator.Simulate
                 { HitResult.Ok, (int)countGood },
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, countMiss }
+            };
+        }
+
+        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
+        {
+            TaikoDifficultyAttributes taikoDifficultyAttributes = (TaikoDifficultyAttributes)difficultyAttributes;
+
+            return new Dictionary<string, double>
+            {
+                { "Star rating", taikoDifficultyAttributes.StarRating },
+                { "Rhythm strain", taikoDifficultyAttributes.RhythmStrain },
+                { "Colour strain", taikoDifficultyAttributes.ColourStrain },
+                { "Stamina strain", taikoDifficultyAttributes.StaminaStrain }
             };
         }
 

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -3,18 +3,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
-using osu.Game.Rulesets.Taiko.Difficulty;
 using osu.Game.Rulesets.Taiko.Objects;
-using osu.Game.Scoring;
 
 namespace PerformanceCalculator.Simulate
 {
@@ -80,19 +76,6 @@ namespace PerformanceCalculator.Simulate
             };
         }
 
-        protected override Dictionary<string, double> GetDifficultyAttributesSkills(DifficultyAttributes difficultyAttributes)
-        {
-            TaikoDifficultyAttributes taikoDifficultyAttributes = (TaikoDifficultyAttributes)difficultyAttributes;
-
-            return new Dictionary<string, double>
-            {
-                { "Star rating", taikoDifficultyAttributes.StarRating },
-                { "Rhythm strain", taikoDifficultyAttributes.RhythmStrain },
-                { "Colour strain", taikoDifficultyAttributes.ColourStrain },
-                { "Stamina strain", taikoDifficultyAttributes.StaminaStrain }
-            };
-        }
-
         protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
         {
             var countGreat = statistics[HitResult.Great];
@@ -101,20 +84,6 @@ namespace PerformanceCalculator.Simulate
             var total = countGreat + countGood + countMiss;
 
             return (double)((2 * countGreat) + countGood) / (2 * total);
-        }
-
-        protected override string GetPlayInfo(ScoreInfo scoreInfo, IBeatmap beatmap)
-        {
-            var playInfo = new List<string>
-            {
-                GetAttribute("Accuracy", (scoreInfo.Accuracy * 100).ToString(CultureInfo.InvariantCulture) + "%"),
-                GetAttribute("Combo", FormattableString.Invariant($"{scoreInfo.MaxCombo} ({Math.Round(100.0 * scoreInfo.MaxCombo / GetMaxCombo(beatmap), 2)}%)")),
-                GetAttribute("Miss", scoreInfo.Statistics[HitResult.Miss].ToString(CultureInfo.InvariantCulture)),
-                GetAttribute("Ok", scoreInfo.Statistics[HitResult.Ok].ToString(CultureInfo.InvariantCulture)),
-                GetAttribute("Great", scoreInfo.Statistics[HitResult.Great].ToString(CultureInfo.InvariantCulture))
-            };
-
-            return string.Join("\n", playInfo);
         }
     }
 }


### PR DESCRIPTION
Alternative to/closes https://github.com/ppy/osu-tools/pull/133.

Prereqs:
- [x] https://github.com/ppy/osu/pull/15633
- [x] Nuget package bump

Sorry for the big PR, since I built this off #133. I can split this out into two PRs if required, but that's probably more work than worth at this point.

## Motivation

Improves output of `difficulty` and `simulate` commands:
- Uses the newly-available JSON serialisation of `DifficultyAttribute`.
- Refactors so that JSON objects are created as classes, rather than as dynamic `JObject`s.
- Adds output of difficulty attributes to `simulate` command, as initially desired in #133.
- Refactors document output of `simulate` command for readability.
- Serialises mods as `APIMod`s so that we will eventually be able to output mod settings. Needs further argument parsing support.

## Example output

<details><summary>Difficulty command (document)</summary>

```
$ dotnet run -- difficulty 129891
ruleset: osu

╔═════════════════════════════════════════════════════════════╤═══════════╤═════════╤══════════╤════════════╤═════════════╤═════════════╤══════════════════╗
║beatmap                                                      │star rating│max combo│aim strain│speed strain│slider factor│approach rate│overall difficulty║
╟─────────────────────────────────────────────────────────────┼───────────┼─────────┼──────────┼────────────┼─────────────┼─────────────┼──────────────────╢
║129891 - xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]│       7.52│ 2,385.00│      3.45│        3.78│         1.00│         9.00│              8.00║
╚═════════════════════════════════════════════════════════════╧═══════════╧═════════╧══════════╧════════════╧═════════════╧═════════════╧══════════════════╝
```
```
$ dotnet run -- difficulty 129891 -m dt -m fl
ruleset: osu

╔═════════════════════════════════════════════════════════════╤═══════════╤═════════╤══════════╤════════════╤═════════════════╤═════════════╤═════════════╤══════════════════╗
║beatmap                                                      │star rating│max combo│aim strain│speed strain│flashlight rating│slider factor│approach rate│overall difficulty║
╟─────────────────────────────────────────────────────────────┼───────────┼─────────┼──────────┼────────────┼─────────────────┼─────────────┼─────────────┼──────────────────╢
║129891 - xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]│      13.80│ 2,385.00│      4.91│        6.38│             6.04│         0.99│        10.33│              9.78║
╚═════════════════════════════════════════════════════════════╧═══════════╧═════════╧══════════╧════════════╧═════════════════╧═════════════╧═════════════╧══════════════════╝
```
```
$ dotnet run -- difficulty 129891 -r:1 -m dt -m fl
ruleset: taiko

╔═════════════════════════════════════════════════════════════╤═══════════╤═════════╤══════════════╤═════════════╤═════════════╤═════════════╤════════════════╗
║beatmap                                                      │star rating│max combo│stamina strain│rhythm strain│colour strain│approach rate│great hit window║
╟─────────────────────────────────────────────────────────────┼───────────┼─────────┼──────────────┼─────────────┼─────────────┼─────────────┼────────────────╢
║129891 - xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]│       8.04│ 2,383.00│          4.42│         1.39│         0.51│         0.00│           17.33║
╚═════════════════════════════════════════════════════════════╧═══════════╧═════════╧══════════════╧═════════════╧═════════════╧═════════════╧════════════════╝
```
Example JSON output:
```json
{
    "errors": [],
    "results": [
        {
            "ruleset_id": 0,
            "beatmap_id": 129891,
            "beatmap": "xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]",
            "mods": [
                {
                    "acronym": "DT",
                    "settings": {}
                },
                {
                    "acronym": "FL",
                    "settings": {}
                }
            ],
            "attributes": {
                "star_rating": 13.801701619047922,
                "max_combo": 2385,
                "aim_strain": 4.905176033761693,
                "speed_strain": 6.378223464796606,
                "flashlight_rating": 6.03613801064017,
                "slider_factor": 0.9936618896141338,
                "approach_rate": 10.333333333333332,
                "overall_difficulty": 9.777777777777779
            }
        }
    ]
}
```

</details>

<details><summary>Simulate command (document)</summary>

```
$ dotnet run -- simulate osu 129891
beatmap             : 129891 - xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]
score               : 0
accuracy            : 100.00
combo               : 2385
mods                : None
---
great               : 1983
ok                  : 0
meh                 : 0
miss                : 0
---
pp                  : 615.26
aim                 : 215.99
speed               : 292.12
accuracy            : 93.53
flashlight          : 0.00
od                  : 8.00
ar                  : 9.00
max combo           : 2,385.00
---
star rating         : 7.52
max combo           : 2,385.00
aim strain          : 3.45
speed strain        : 3.78
slider factor       : 1.00
approach rate       : 9.00
overall difficulty  : 8.00
```
```
$ dotnet run -- simulate osu 129891 -m dt -m fl
beatmap             : 129891 - xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]
score               : 0
accuracy            : 100.00
combo               : 2385
mods                : DT, FL
---
great               : 1983
ok                  : 0
meh                 : 0
miss                : 0
---
pp                  : 3,275.42
aim                 : 637.11
speed               : 1,493.65
accuracy            : 201.22
flashlight          : 927.49
od                  : 9.78
ar                  : 10.33
max combo           : 2,385.00
---
star rating         : 13.80
max combo           : 2,385.00
aim strain          : 4.91
speed strain        : 6.38
flashlight rating   : 6.04
slider factor       : 0.99
approach rate       : 10.33
overall difficulty  : 9.78
```
```
$ dotnet run -- simulate taiko 129891 -m dt -m fl
beatmap             : 129891 - xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]
score               : 0
accuracy            : 100.00
combo               : 2383
mods                : DT, FL
---
great               : 2383
ok                  : 0
meh                 : 0
miss                : 0
---
pp                  : 657.07
strain              : 364.08
accuracy            : 271.43
---
star rating         : 8.04
max combo           : 2,383.00
stamina strain      : 4.42
rhythm strain       : 1.39
colour strain       : 0.51
approach rate       : 0.00
great hit window    : 17.33

```
Example JSON output:
```json
{
    "score": {
        "ruleset_id": 0,
        "beatmap_id": 129891,
        "beatmap": "xi - FREEDOM DiVE (Nakagawa-Kanon) [FOUR DIMENSIONS]",
        "mods": [
            {
                "acronym": "DT",
                "settings": {}
            },
            {
                "acronym": "FL",
                "settings": {}
            }
        ],
        "total_score": 0,
        "accuracy": 100,
        "combo": 2385,
        "statistics": {
            "Great": 1983,
            "Ok": 0,
            "Meh": 0,
            "Miss": 0
        }
    },
    "pp": 3275.417075366126,
    "performance_attributes": {
        "aim": 637.1091326884399,
        "speed": 1493.6534665870317,
        "accuracy": 201.21573699876296,
        "flashlight": 927.4901940548373,
        "od": 9.777777777777779,
        "ar": 10.333333333333332,
        "max_combo": 2385
    },
    "difficulty_attributes": {
        "star_rating": 13.801701619047922,
        "max_combo": 2385,
        "aim_strain": 4.905176033761693,
        "speed_strain": 6.378223464796606,
        "flashlight_rating": 6.03613801064017,
        "slider_factor": 0.9936618896141338,
        "approach_rate": 10.333333333333332,
        "overall_difficulty": 9.777777777777779
    }
}
```

</details>