### PR TITLE
Fix inconsistent locale handling in simulate output

### DIFF
--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -142,7 +142,7 @@ namespace PerformanceCalculator.Simulate
                 foreach (var attrib in result.PerformanceAttributes)
                 {
                     // For the time being, we don't have explicitly defined storage for these attributes.
-                    document.Children.Add(FormatDocumentLine(attrib.Key.Humanize().ToLowerInvariant(), attrib.Value.ToString("N2")));
+                    document.Children.Add(FormatDocumentLine(attrib.Key.Humanize().ToLowerInvariant(), attrib.Value.ToString("N2", CultureInfo.InvariantCulture)));
                 }
 
                 document.Children.Add("---\n");
@@ -150,7 +150,7 @@ namespace PerformanceCalculator.Simulate
                 // Difficulty attributes.
                 var attributeValues = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(result.DifficultyAttributes)) ?? new Dictionary<string, object>();
                 foreach (var attrib in attributeValues)
-                    document.Children.Add(FormatDocumentLine(attrib.Key.Humanize(), $"{attrib.Value:N2}"));
+                    document.Children.Add(FormatDocumentLine(attrib.Key.Humanize(), FormattableString.Invariant($"{attrib.Value:N2}")));
 
                 OutputDocument(document);
             }


### PR DESCRIPTION
Closes #137.

For reproduction of the original bug, I recommend running with non-English locales (can be done by setting e.g. `LC_ALL=pl-PL` on Unices).

<details>
<summary>Example output before</summary>

```
beatmap             : 951401 - Dendei - gabe power (HighTec) [Cheesecake's Easy]
score               : 0
accuracy            : 79.82
combo               : 14
mods                : None
---
great               : 14
ok                  : 2
meh                 : 3
miss                : 0
---
pp                  : 0.03
aim                 : 0,03
speed               : 0,00
accuracy            : 0,00
flashlight          : 0,00
od                  : 2,00
ar                  : 2,00
max combo           : 83,00
---
star rating         : 1,25
max combo           : 83,00
aim strain          : 0,70
speed strain        : 0,43
slider factor       : 0,77
approach rate       : 2,00
overall difficulty  : 2,00
```

</details>

<details>
<summary>Example output after</summary>

```
beatmap             : 951401 - Dendei - gabe power (HighTec) [Cheesecake's Easy]
score               : 0
accuracy            : 79.82
combo               : 14
mods                : None
---
great               : 14
ok                  : 2
meh                 : 3
miss                : 0
---
pp                  : 0.03
aim                 : 0.03
speed               : 0.00
accuracy            : 0.00
flashlight          : 0.00
od                  : 2.00
ar                  : 2.00
max combo           : 83.00
---
star rating         : 1.25
max combo           : 83.00
aim strain          : 0.70
speed strain        : 0.43
slider factor       : 0.77
approach rate       : 2.00
overall difficulty  : 2.00
```

</details>

`.ToString(string, IFormatProvider)` cannot be used in both places; the second usage needs to use `FormattableString.Invariant()` because in that case the argument is an `object` and not a `double`.