### PR TITLE
Add section headers to simulate output

### DIFF
--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -119,7 +119,8 @@ namespace PerformanceCalculator.Simulate
             {
                 var document = new Document();
 
-                // Basic score info.
+                AddSectionHeader(document, "Basic score info");
+
                 document.Children.Add(
                     FormatDocumentLine("beatmap", $"{result.Score.BeatmapId} - {result.Score.Beatmap}"),
                     FormatDocumentLine("score", result.Score.Score.ToString(CultureInfo.InvariantCulture)),
@@ -128,15 +129,13 @@ namespace PerformanceCalculator.Simulate
                     FormatDocumentLine("mods", result.Score.Mods.Count > 0 ? result.Score.Mods.Select(m => m.ToString()).Aggregate((c, n) => $"{c}, {n}") : "None")
                 );
 
-                document.Children.Add("---\n");
+                AddSectionHeader(document, "Hit statistics");
 
-                // Hit statistics.
                 foreach (var stat in result.Score.Statistics)
                     document.Children.Add(FormatDocumentLine(stat.Key.ToString().ToLowerInvariant(), stat.Value.ToString(CultureInfo.InvariantCulture)));
 
-                document.Children.Add("---\n");
+                AddSectionHeader(document, "Performance attributes");
 
-                // Performance attributes.
                 document.Children.Add(FormatDocumentLine("pp", result.Pp.ToString("N2", CultureInfo.InvariantCulture)));
 
                 foreach (var attrib in result.PerformanceAttributes)
@@ -145,15 +144,23 @@ namespace PerformanceCalculator.Simulate
                     document.Children.Add(FormatDocumentLine(attrib.Key.Humanize().ToLowerInvariant(), attrib.Value.ToString("N2", CultureInfo.InvariantCulture)));
                 }
 
-                document.Children.Add("---\n");
+                AddSectionHeader(document, "Difficulty attributes");
 
-                // Difficulty attributes.
                 var attributeValues = JsonConvert.DeserializeObject<Dictionary<string, object>>(JsonConvert.SerializeObject(result.DifficultyAttributes)) ?? new Dictionary<string, object>();
                 foreach (var attrib in attributeValues)
                     document.Children.Add(FormatDocumentLine(attrib.Key.Humanize(), FormattableString.Invariant($"{attrib.Value:N2}")));
 
                 OutputDocument(document);
             }
+        }
+
+        protected void AddSectionHeader(Document document, string header)
+        {
+            if (document.Children.Any())
+                document.Children.Add(Environment.NewLine);
+
+            document.Children.Add(header);
+            document.Children.Add(new Separator());
         }
 
         protected List<Mod> GetMods(Ruleset ruleset)


### PR DESCRIPTION
As proposed in https://github.com/ppy/osu-tools/issues/137#issuecomment-996091249.

<details>
<summary>Example output before</summary>

```
beatmap             : 951401 - Dendei - gabe power (HighTec) [Cheesecake's Easy]
score               : 0
accuracy            : 79.82
combo               : 14
mods                : None
---
great               : 14
ok                  : 2
meh                 : 3
miss                : 0
---
pp                  : 0.03
aim                 : 0.03
speed               : 0.00
accuracy            : 0.00
flashlight          : 0.00
od                  : 2.00
ar                  : 2.00
max combo           : 83.00
---
star rating         : 1.25
max combo           : 83.00
aim strain          : 0.70
speed strain        : 0.43
slider factor       : 0.77
approach rate       : 2.00
overall difficulty  : 2.00
```

</details>

<details>
<summary>Example output after</summary>

```
Basic score info
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
beatmap             : 951401 - Dendei - gabe power (HighTec) [Cheesecake's Easy]
score               : 0
accuracy            : 79.82
combo               : 14
mods                : None

Hit statistics
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
great               : 14
ok                  : 2
meh                 : 3
miss                : 0

Performance attributes
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
pp                  : 0.03
aim                 : 0.03
speed               : 0.00
accuracy            : 0.00
flashlight          : 0.00
od                  : 2.00
ar                  : 2.00
max combo           : 83.00

Difficulty attributes
──────────────────────────────────────────────────────────────────────────────────────────────────────────────
star rating         : 1.25
max combo           : 83.00
aim strain          : 0.70
speed strain        : 0.43
slider factor       : 0.77
approach rate       : 2.00
overall difficulty  : 2.00

```

</details>

I made the headering function protected for consistency with other formatting functions / future extensibility even though it is rather useless right now and could as well be private.