### PR TITLE
Update model class usages in line with latest changes

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -125,14 +125,14 @@ namespace PerformanceCalculator.Difficulty
         private Result processBeatmap(WorkingBeatmap beatmap)
         {
             // Get the ruleset
-            var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.RulesetID);
+            var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.Ruleset.OnlineID);
             var mods = LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, getMods(ruleset).ToArray());
             var attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(mods);
 
             return new Result
             {
                 RulesetId = ruleset.RulesetInfo.OnlineID,
-                BeatmapId = beatmap.BeatmapInfo.OnlineID ?? 0,
+                BeatmapId = beatmap.BeatmapInfo.OnlineID,
                 Beatmap = beatmap.BeatmapInfo.ToString(),
                 Mods = mods.Select(m => new APIMod(m)).ToList(),
                 Attributes = attributes

--- a/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
+++ b/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
@@ -63,9 +63,8 @@ namespace PerformanceCalculator.Leaderboard
                     var modsAcronyms = ((JArray)play.mods).Select(x => x.ToString()).ToArray();
                     Mod[] mods = ruleset.CreateAllMods().Where(m => modsAcronyms.Contains(m.Acronym)).ToArray();
 
-                    var scoreInfo = new ScoreInfo
+                    var scoreInfo = new ScoreInfo(working.BeatmapInfo, ruleset.RulesetInfo)
                     {
-                        Ruleset = ruleset.RulesetInfo,
                         TotalScore = play.score,
                         MaxCombo = play.max_combo,
                         Mods = mods,

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -73,7 +73,7 @@ namespace PerformanceCalculator
                 BeatmapInfo =
                 {
                     Ruleset = ruleset.RulesetInfo,
-                    BaseDifficulty = new BeatmapDifficulty()
+                    Difficulty = new BeatmapDifficulty()
                 }
             };
 

--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Alba.CsConsoleFormat" Version="1.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="ppy.osu.Game" Version="2021.1225.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2021.1225.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2021.1225.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2021.1225.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2021.1225.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2022.128.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.128.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.128.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.128.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.128.0" />
   </ItemGroup>
 </Project>

--- a/PerformanceCalculator/ProcessorWorkingBeatmap.cs
+++ b/PerformanceCalculator/ProcessorWorkingBeatmap.cs
@@ -35,10 +35,10 @@ namespace PerformanceCalculator
         {
             this.beatmap = beatmap;
 
-            beatmap.BeatmapInfo.Ruleset = LegacyHelper.GetRulesetFromLegacyID(beatmap.BeatmapInfo.RulesetID).RulesetInfo;
+            beatmap.BeatmapInfo.Ruleset = LegacyHelper.GetRulesetFromLegacyID(beatmap.BeatmapInfo.Ruleset.OnlineID).RulesetInfo;
 
             if (beatmapId.HasValue)
-                beatmap.BeatmapInfo.OnlineID = beatmapId;
+                beatmap.BeatmapInfo.OnlineID = beatmapId.Value;
         }
 
         private static Beatmap readFromFile(string filename)

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -55,9 +55,8 @@ namespace PerformanceCalculator.Profile
                 var modsAcronyms = ((JArray)play.mods).Select(x => x.ToString()).ToArray();
                 Mod[] mods = ruleset.CreateAllMods().Where(m => modsAcronyms.Contains(m.Acronym)).ToArray();
 
-                var scoreInfo = new ScoreInfo
+                var scoreInfo = new ScoreInfo(working.BeatmapInfo, ruleset.RulesetInfo)
                 {
-                    Ruleset = ruleset.RulesetInfo,
                     TotalScore = play.score,
                     MaxCombo = play.max_combo,
                     Mods = mods,

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -75,14 +75,13 @@ namespace PerformanceCalculator.Simulate
 
             var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
             var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, mods).ToArray());
-            var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, new ScoreInfo
+            var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, new ScoreInfo(beatmap.BeatmapInfo, ruleset.RulesetInfo)
             {
                 Accuracy = accuracy,
                 MaxCombo = maxCombo,
                 Statistics = statistics,
                 Mods = mods,
                 TotalScore = score,
-                Ruleset = Ruleset.RulesetInfo,
             });
 
             var ppAttributes = performanceCalculator?.Calculate();

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -82,7 +82,7 @@ namespace PerformanceCalculator.Simulate
                 Statistics = statistics,
                 Mods = mods,
                 TotalScore = score,
-                RulesetID = Ruleset.RulesetInfo.ID ?? 0,
+                Ruleset = Ruleset.RulesetInfo,
             });
 
             var ppAttributes = performanceCalculator?.Calculate();
@@ -92,7 +92,7 @@ namespace PerformanceCalculator.Simulate
                 Score = new ScoreStatistics
                 {
                     RulesetId = ruleset.RulesetInfo.OnlineID,
-                    BeatmapId = workingBeatmap.BeatmapInfo.OnlineID ?? 0,
+                    BeatmapId = workingBeatmap.BeatmapInfo.OnlineID,
                     Beatmap = workingBeatmap.BeatmapInfo.ToString(),
                     Mods = mods.Select(m => new APIMod(m)).ToList(),
                     Score = score,


### PR DESCRIPTION
Bumps game packages to latest releases and updates usages of `OnlineID`, `BaseDifficulty` and `ScoreInfo` to match latest changes.

Have briefly locally compared against `master` and things appear to be mostly unchanged. The exception to that is osu! pp numbers, which (I believe) would have been impacted by ppy/osu#16331, which was merged inbetween the model changes.