### PR TITLE
Add support for lazer-first scores

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -43,8 +43,8 @@ namespace PerformanceCalculator.Difficulty
         public bool OutputJson { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-l|--lazer", Description = "Excludes the classic mod to compute lazer-first scores.")]
-        public bool Lazer { get; }
+        [Option(Template = "-nc|--no-classic", Description = "Excludes the classic mod.")]
+        public bool NoClassicMod { get; }
 
         public override void Execute()
         {
@@ -130,7 +130,7 @@ namespace PerformanceCalculator.Difficulty
         {
             // Get the ruleset
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.Ruleset.OnlineID);
-            var mods = Lazer ? getMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, getMods(ruleset));
+            var mods = NoClassicMod ? getMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, getMods(ruleset));
             var attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(mods);
 
             return new Result

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -42,6 +42,10 @@ namespace PerformanceCalculator.Difficulty
         [Option(Template = "-j|--json", Description = "Output results as JSON.")]
         public bool OutputJson { get; }
 
+        [UsedImplicitly]
+        [Option(Template = "-l|--lazer", Description = "Excludes the classic mod to compute lazer-first scores.")]
+        public bool Lazer { get; }
+
         public override void Execute()
         {
             var resultSet = new ResultSet();
@@ -126,7 +130,7 @@ namespace PerformanceCalculator.Difficulty
         {
             // Get the ruleset
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.Ruleset.OnlineID);
-            var mods = LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, getMods(ruleset).ToArray());
+            var mods = Lazer ? getMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, getMods(ruleset));
             var attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(mods);
 
             return new Result
@@ -139,11 +143,11 @@ namespace PerformanceCalculator.Difficulty
             };
         }
 
-        private List<Mod> getMods(Ruleset ruleset)
+        private Mod[] getMods(Ruleset ruleset)
         {
             var mods = new List<Mod>();
             if (Mods == null)
-                return mods;
+                return Array.Empty<Mod>();
 
             var availableMods = ruleset.CreateAllMods().ToList();
 
@@ -156,7 +160,7 @@ namespace PerformanceCalculator.Difficulty
                 mods.Add(newMod);
             }
 
-            return mods;
+            return mods.ToArray();
         }
 
         private class ResultSet

--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -126,7 +126,7 @@ namespace PerformanceCalculator.Difficulty
         {
             // Get the ruleset
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.Ruleset.OnlineID);
-            var mods = LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, getMods(ruleset).ToArray());
+            var mods = LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, getMods(ruleset).ToArray());
             var attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(mods);
 
             return new Result

--- a/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
+++ b/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
@@ -81,7 +81,7 @@ namespace PerformanceCalculator.Leaderboard
                     var score = new ProcessorScoreDecoder(working).Parse(scoreInfo);
 
                     var difficultyCalculator = ruleset.CreateDifficultyCalculator(working);
-                    var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, scoreInfo.Mods).ToArray());
+                    var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, scoreInfo.Mods).ToArray());
                     var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, score.ScoreInfo);
 
                     plays.Add((performanceCalculator?.Calculate().Total ?? 0, play.pp));

--- a/PerformanceCalculator/Performance/PerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/PerformanceCommand.cs
@@ -10,6 +10,7 @@ using Humanizer;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using Newtonsoft.Json;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Scoring;
 
 namespace PerformanceCalculator.Performance
@@ -40,7 +41,12 @@ namespace PerformanceCalculator.Performance
 
                 var ruleset = score.ScoreInfo.Ruleset.CreateInstance();
                 var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
-                var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, score.ScoreInfo.Mods).ToArray());
+
+                Mod[] mods = score.ScoreInfo.Mods;
+                if (score.ScoreInfo.IsLegacyScore)
+                    mods = LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, mods);
+
+                var difficultyAttributes = difficultyCalculator.Calculate(mods);
                 var performanceCalculator = score.ScoreInfo.Ruleset.CreateInstance().CreatePerformanceCalculator(difficultyAttributes, score.ScoreInfo);
 
                 var ppAttributes = performanceCalculator?.Calculate();

--- a/PerformanceCalculator/Performance/PerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/PerformanceCommand.cs
@@ -40,7 +40,7 @@ namespace PerformanceCalculator.Performance
 
                 var ruleset = score.ScoreInfo.Ruleset.CreateInstance();
                 var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
-                var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, score.ScoreInfo.Mods).ToArray());
+                var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, score.ScoreInfo.Mods).ToArray());
                 var performanceCalculator = score.ScoreInfo.Ruleset.CreateInstance().CreatePerformanceCalculator(difficultyAttributes, score.ScoreInfo);
 
                 var ppAttributes = performanceCalculator?.Calculate();

--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Alba.CsConsoleFormat" Version="1.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.1" />
-    <PackageReference Include="ppy.osu.Game" Version="2022.319.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.319.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.319.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.319.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.319.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2022.409.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2022.409.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2022.409.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2022.409.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2022.409.0" />
   </ItemGroup>
 </Project>

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -73,7 +73,7 @@ namespace PerformanceCalculator.Profile
                 var score = new ProcessorScoreDecoder(working).Parse(scoreInfo);
 
                 var difficultyCalculator = ruleset.CreateDifficultyCalculator(working);
-                var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, scoreInfo.Mods).ToArray());
+                var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, scoreInfo.Mods).ToArray());
                 var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, score.ScoreInfo);
 
                 var ppAttributes = performanceCalculator?.Calculate();

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 
 namespace PerformanceCalculator.Simulate
@@ -50,7 +48,7 @@ namespace PerformanceCalculator.Simulate
 
         public override Ruleset Ruleset => new OsuRuleset();
 
-        protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.HitObjects.Count + beatmap.HitObjects.OfType<Slider>().Sum(s => s.NestedHitObjects.Count - 1);
+        protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.GetMaxCombo();
 
         protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
         {

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -74,7 +74,7 @@ namespace PerformanceCalculator.Simulate
             var accuracy = GetAccuracy(statistics);
 
             var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
-            var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.TrimNonDifficultyAdjustmentMods(ruleset, mods).ToArray());
+            var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, mods).ToArray());
             var performanceCalculator = ruleset.CreatePerformanceCalculator(difficultyAttributes, new ScoreInfo(beatmap.BeatmapInfo, ruleset.RulesetInfo)
             {
                 Accuracy = accuracy,

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -60,14 +60,14 @@ namespace PerformanceCalculator.Simulate
         public bool OutputJson { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-l|--lazer", Description = "Excludes the classic mod to compute lazer-first scores.")]
-        public bool Lazer { get; }
+        [Option(Template = "-nc|--no-classic", Description = "Excludes the classic mod.")]
+        public bool NoClassicMod { get; }
 
         public override void Execute()
         {
             var ruleset = Ruleset;
 
-            var mods = Lazer ? GetMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, GetMods(ruleset));
+            var mods = NoClassicMod ? GetMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, GetMods(ruleset));
             var workingBeatmap = ProcessorWorkingBeatmap.FromFileOrId(Beatmap);
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/16575

- Added for `difficulty` and `simulate` commands if you provide the `-l` or `--lazer` arguments. I think this is best for now since classic scores are the most common.
- Added for `performance` command if you provide a lazer replay.