### PR TITLE
Use correct shell for local osu script

### DIFF
--- a/UseLocalOsu.sh
+++ b/UseLocalOsu.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Run this script to use a local copy of osu rather than fetching it from nuget.
 # It expects the osu directory to be at the same level as the osu-tools directory


### PR DESCRIPTION
The script uses bashism (array) and thus running `./UseLocalOsu.sh` won't work on systems which `/bin/sh` isn't bash.