### PR TITLE
Remove StaminaCheese bool from objectInspection

### DIFF
--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/TaikoObjectInspectorRuleset.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/TaikoObjectInspectorRuleset.cs
@@ -75,9 +75,6 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
                     panel.AddParagraph($"Delta Time: {dho.DeltaTime:N3}");
                     panel.AddParagraph($"Rhythm Difficulty: {dho.Rhythm.Difficulty:N3}");
                     panel.AddParagraph($"Rhythm Ratio: {dho.Rhythm.Ratio:N3}");
-
-                    if (dho.StaminaCheese)
-                        panel.AddParagraph("Stamina Cheese!!!");
                 }
 
                 public override bool OnPressed(KeyBindingPressEvent<TaikoAction> e) => true;


### PR DESCRIPTION
This has been redundant since the first osu!taiko diffcalc pr, and due to us not removing the bool by accident, all objects are marked as a stamina cheese object in the GUI Object Inspector.

This is also removed in diffcalc within ppy/osu#19184 either way.

