### PR TITLE
Simulate osu!mania scores by accuracy and counts

### DIFF
--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -53,7 +53,7 @@ namespace PerformanceCalculator.Simulate
         protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.HitObjects.Count(h => h is Fruit)
                                                                 + beatmap.HitObjects.OfType<JuiceStream>().SelectMany(j => j.NestedHitObjects).Count(h => !(h is TinyDroplet));
 
-        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? countGreat)
         {
             var maxCombo = GetMaxCombo(beatmap);
             int maxTinyDroplets = beatmap.HitObjects.OfType<JuiceStream>().Sum(s => s.NestedHitObjects.OfType<TinyDroplet>().Count());

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -17,61 +17,97 @@ namespace PerformanceCalculator.Simulate
     [Command(Name = "mania", Description = "Computes the performance (pp) of a simulated osu!mania play.")]
     public class ManiaSimulateCommand : SimulateCommand
     {
-        public override int Score
-        {
-            get
-            {
-                Debug.Assert(score != null);
-                return score.Value;
-            }
-        }
-
         [UsedImplicitly]
-        [Option(Template = "-s|--score <score>", Description = "Score. An integer 0-1000000.")]
-        private int? score { get; set; }
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
+                                                                     + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
+        public override double Accuracy { get; } = 100;
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
                                                                                             + " Values: hr, dt, fl, 4k, 5k, etc...")]
         public override string[] Mods { get; }
 
+        [UsedImplicitly]
+        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
+        public override int Misses { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-M|--mehs <mehs>", Description = "Number of mehs (50). Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Mehs { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-O|--oks <oks>", Description = "Number of oks (100).")]
+        public override int? Oks { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-G|--goods <goods>", Description = "Number of goods (200).")]
+        public override int? Goods { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-GR|--greats <greats>", Description = "Number of greats (300).")]
+        public override int? Greats { get; }
+
         public override Ruleset Ruleset => new ManiaRuleset();
-
-        public override void Execute()
-        {
-            if (score == null)
-            {
-                double scoreMultiplier = 1;
-
-                // Cap score depending on difficulty adjustment mods (matters for mania).
-                foreach (var mod in GetMods(Ruleset))
-                {
-                    if (mod.Type == ModType.DifficultyReduction)
-                        scoreMultiplier *= mod.ScoreMultiplier;
-                }
-
-                score = (int)Math.Round(1000000 * scoreMultiplier);
-            }
-
-            base.Execute();
-        }
 
         protected override int GetMaxCombo(IBeatmap beatmap) => 0;
 
-        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? countGreat)
         {
             var totalHits = beatmap.HitObjects.Count;
 
-            // Only total number of hits is considered currently, so specifics don't matter
+            countMiss = Math.Clamp(countMiss, 0, totalHits);
+
+            if (countMeh == null)
+            {
+                // Populate score with mehs to make this approximation more precise.
+                // This value can be negative on impossible misscount.
+                //
+                // total = ((1/6) * meh + (1/3) * ok + (2/3) * good + great + perfect) / acc
+                // total = miss + meh + ok + good + great + perfect
+                // 
+                // miss + (5/6) * meh + (2/3) * ok + (1/3) * good = total - acc * total
+                // meh = 1.2 * (total - acc * total) - 1.2 * miss - 0.8 * ok - 0.4 * good
+                countMeh = (int)Math.Round(1.2 * (totalHits - totalHits * accuracy) - 1.2 * countMiss - 0.8 * (countOk ?? 0) - 0.4 * (countGood ?? 0));
+            }
+
+            // We need to clamp for all values because performance calculator's custom accuracy formula is not invariant to negative counts.
+            int currentCounts = countMiss;
+
+            countMeh = Math.Clamp(countMeh ?? 0, 0, totalHits - currentCounts);
+            currentCounts += countMeh ?? 0;
+
+            countOk = Math.Clamp(countOk ?? 0, 0, totalHits - currentCounts);
+            currentCounts += countOk ?? 0;
+
+            countGood = Math.Clamp(countGood ?? 0, 0, totalHits - currentCounts);
+            currentCounts += countGood ?? 0;
+
+            countGreat = Math.Clamp(countGreat ?? 0, 0, totalHits - currentCounts);
+
+            int countPerfect = totalHits - (countGreat ?? 0) - (countGood ?? 0) - (countOk ?? 0) - (countMeh ?? 0) - countMiss;
+
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Perfect, totalHits },
-                { HitResult.Great, 0 },
-                { HitResult.Ok, 0 },
-                { HitResult.Good, 0 },
-                { HitResult.Meh, 0 },
-                { HitResult.Miss, 0 }
+                { HitResult.Perfect, countPerfect },
+                { HitResult.Great, countGreat ?? 0 },
+                { HitResult.Ok, countOk ?? 0 },
+                { HitResult.Good, countGood ?? 0 },
+                { HitResult.Meh, countMeh ?? 0 },
+                { HitResult.Miss, countMiss }
             };
+        }
+
+        protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
+        {
+            var countPerfect = statistics[HitResult.Perfect];
+            var countGreat = statistics[HitResult.Great];
+            var countGood = statistics[HitResult.Good];
+            var countOk = statistics[HitResult.Ok];
+            var countMeh = statistics[HitResult.Meh];
+            var countMiss = statistics[HitResult.Miss];
+            var total = countPerfect + countGreat + countGood + countOk + countMeh + countMiss;
+
+            return (double)(countMeh / 6.0 + countOk / 3.0 + countGood / 1.5 + countGreat + countPerfect) / total;
         }
     }
 }

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -64,10 +64,10 @@ namespace PerformanceCalculator.Simulate
                 //
                 // total = ((1/6) * meh + (1/3) * ok + (2/3) * good + great + perfect) / acc
                 // total = miss + meh + ok + good + great + perfect
-                // 
+                //
                 // miss + (5/6) * meh + (2/3) * ok + (1/3) * good = total - acc * total
                 // meh = 1.2 * (total - acc * total) - 1.2 * miss - 0.8 * ok - 0.4 * good
-                countMeh = (int)Math.Round(1.2 * (totalHits - totalHits * accuracy) - 1.2 * countMiss - 0.8 * (countOk ?? 0) - 0.4 * (countGood ?? 0));
+                countMeh = (int)Math.Round((1.2 * (totalHits - totalHits * accuracy)) - (1.2 * countMiss) - (0.8 * (countOk ?? 0)) - (0.4 * (countGood ?? 0)));
             }
 
             // We need to clamp for all values because performance calculator's custom accuracy formula is not invariant to negative counts.
@@ -107,7 +107,7 @@ namespace PerformanceCalculator.Simulate
             var countMiss = statistics[HitResult.Miss];
             var total = countPerfect + countGreat + countGood + countOk + countMeh + countMiss;
 
-            return (double)(countMeh / 6.0 + countOk / 3.0 + countGood / 1.5 + countGreat + countPerfect) / total;
+            return (double)(((countMeh / 6.0) + (countOk / 3.0) + (countGood / 1.5) + countGreat + countPerfect) / total);
         }
     }
 }

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -68,7 +68,7 @@ namespace PerformanceCalculator.Simulate
             // We need to clamp for all values because performance calculator's custom accuracy formula is not invariant to negative counts.
             int currentCounts = countMiss;
 
-            countMeh = Math.Clamp(countMeh ?? 0, 0, totalHits - currentCounts);
+            countMeh = Math.Clamp((int)countMeh, 0, totalHits - currentCounts);
             currentCounts += (int)countMeh;
 
             countOk = Math.Clamp(countOk ?? 0, 0, totalHits - currentCounts);
@@ -84,10 +84,10 @@ namespace PerformanceCalculator.Simulate
             return new Dictionary<HitResult, int>
             {
                 { HitResult.Perfect, countPerfect },
-                { HitResult.Great, countGreat ?? 0 },
-                { HitResult.Ok, countOk ?? 0 },
-                { HitResult.Good, countGood ?? 0 },
-                { HitResult.Meh, countMeh ?? 0 },
+                { HitResult.Great, (int)countGreat },
+                { HitResult.Ok, (int)countOk },
+                { HitResult.Good, (int)countGood },
+                { HitResult.Meh, (int)countMeh },
                 { HitResult.Miss, countMiss }
             };
         }
@@ -102,7 +102,7 @@ namespace PerformanceCalculator.Simulate
             var countMiss = statistics[HitResult.Miss];
             var total = countPerfect + countGreat + countGood + countOk + countMeh + countMiss;
 
-            return (double)(((countMeh / 6.0) + (countOk / 3.0) + (countGood / 1.5) + countGreat + countPerfect) / total);
+            return ((countMeh / 6.0) + (countOk / 3.0) + (countGood / 1.5) + countGreat + countPerfect) / total;
         }
     }
 }

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -3,13 +3,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mania;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 
 namespace PerformanceCalculator.Simulate
@@ -57,34 +55,31 @@ namespace PerformanceCalculator.Simulate
 
             countMiss = Math.Clamp(countMiss, 0, totalHits);
 
-            if (countMeh == null)
-            {
-                // Populate score with mehs to make this approximation more precise.
-                // This value can be negative on impossible misscount.
-                //
-                // total = ((1/6) * meh + (1/3) * ok + (2/3) * good + great + perfect) / acc
-                // total = miss + meh + ok + good + great + perfect
-                //
-                // miss + (5/6) * meh + (2/3) * ok + (1/3) * good = total - acc * total
-                // meh = 1.2 * (total - acc * total) - 1.2 * miss - 0.8 * ok - 0.4 * good
-                countMeh = (int)Math.Round((1.2 * (totalHits - totalHits * accuracy)) - (1.2 * countMiss) - (0.8 * (countOk ?? 0)) - (0.4 * (countGood ?? 0)));
-            }
+            // Populate score with mehs to make this approximation more precise.
+            // This value can be negative on impossible misscount.
+            //
+            // total = ((1/6) * meh + (1/3) * ok + (2/3) * good + great + perfect) / acc
+            // total = miss + meh + ok + good + great + perfect
+            //
+            // miss + (5/6) * meh + (2/3) * ok + (1/3) * good = total - acc * total
+            // meh = 1.2 * (total - acc * total) - 1.2 * miss - 0.8 * ok - 0.4 * good
+            countMeh ??= (int)Math.Round((1.2 * (totalHits - totalHits * accuracy)) - (1.2 * countMiss) - (0.8 * (countOk ?? 0)) - (0.4 * (countGood ?? 0)));
 
             // We need to clamp for all values because performance calculator's custom accuracy formula is not invariant to negative counts.
             int currentCounts = countMiss;
 
             countMeh = Math.Clamp(countMeh ?? 0, 0, totalHits - currentCounts);
-            currentCounts += countMeh ?? 0;
+            currentCounts += (int)countMeh;
 
             countOk = Math.Clamp(countOk ?? 0, 0, totalHits - currentCounts);
-            currentCounts += countOk ?? 0;
+            currentCounts += (int)countOk;
 
             countGood = Math.Clamp(countGood ?? 0, 0, totalHits - currentCounts);
-            currentCounts += countGood ?? 0;
+            currentCounts += (int)countGood;
 
             countGreat = Math.Clamp(countGreat ?? 0, 0, totalHits - currentCounts);
 
-            int countPerfect = totalHits - (countGreat ?? 0) - (countGood ?? 0) - (countOk ?? 0) - (countMeh ?? 0) - countMiss;
+            int countPerfect = totalHits - (int)countGreat - (int)countGood - (int)countOk - (int)countMeh - countMiss;
 
             return new Dictionary<HitResult, int>
             {

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -50,9 +50,11 @@ namespace PerformanceCalculator.Simulate
 
         protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.GetMaxCombo();
 
-        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? countGreat)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? _)
         {
             var totalResultCount = beatmap.HitObjects.Count;
+
+            int countGreat;
 
             if (countMeh != null || countGood != null)
             {
@@ -77,7 +79,7 @@ namespace PerformanceCalculator.Simulate
 
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Great, (int)countGreat },
+                { HitResult.Great, countGreat },
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
                 { HitResult.Miss, countMiss }

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -77,7 +77,7 @@ namespace PerformanceCalculator.Simulate
 
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Great, countGreat ?? 0 },
+                { HitResult.Great, (int)countGreat },
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
                 { HitResult.Miss, countMiss }

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -50,10 +50,8 @@ namespace PerformanceCalculator.Simulate
 
         protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.GetMaxCombo();
 
-        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? countGreat)
         {
-            int countGreat;
-
             var totalResultCount = beatmap.HitObjects.Count;
 
             if (countMeh != null || countGood != null)
@@ -79,7 +77,7 @@ namespace PerformanceCalculator.Simulate
 
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Great, countGreat },
+                { HitResult.Great, countGreat ?? 0 },
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
                 { HitResult.Miss, countMiss }

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -53,7 +53,13 @@ namespace PerformanceCalculator.Simulate
         public virtual int? Mehs { get; }
 
         [UsedImplicitly]
+        public virtual int? Oks { get; }
+
+        [UsedImplicitly]
         public virtual int? Goods { get; }
+
+        [UsedImplicitly]
+        public virtual int? Greats { get; }
 
         [UsedImplicitly]
         [Option(Template = "-j|--json", Description = "Output results as JSON.")]
@@ -73,7 +79,7 @@ namespace PerformanceCalculator.Simulate
 
             var beatmapMaxCombo = GetMaxCombo(beatmap);
             var maxCombo = Combo ?? (int)Math.Round(PercentCombo / 100 * beatmapMaxCombo);
-            var statistics = GenerateHitResults(Accuracy / 100, beatmap, Misses, Mehs, Goods);
+            var statistics = GenerateHitResults(Accuracy / 100, beatmap, Misses, Mehs, Oks, Goods, Greats);
             var score = Score;
             var accuracy = GetAccuracy(statistics);
 
@@ -182,7 +188,7 @@ namespace PerformanceCalculator.Simulate
 
         protected abstract int GetMaxCombo(IBeatmap beatmap);
 
-        protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood);
+        protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? countGreat);
 
         protected virtual double GetAccuracy(Dictionary<HitResult, int> statistics) => 0;
 

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -48,9 +48,11 @@ namespace PerformanceCalculator.Simulate
 
         protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.HitObjects.OfType<Hit>().Count();
 
-        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? countGreat)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? _)
         {
             var totalResultCount = GetMaxCombo(beatmap);
+
+            int countGreat;
 
             if (countGood != null)
             {
@@ -67,7 +69,7 @@ namespace PerformanceCalculator.Simulate
 
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Great, (int)countGreat },
+                { HitResult.Great, countGreat },
                 { HitResult.Ok, (int)countGood },
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, countMiss }

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -48,11 +48,9 @@ namespace PerformanceCalculator.Simulate
 
         protected override int GetMaxCombo(IBeatmap beatmap) => beatmap.HitObjects.OfType<Hit>().Count();
 
-        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
+        protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countOk, int? countGood, int? countGreat)
         {
             var totalResultCount = GetMaxCombo(beatmap);
-
-            int countGreat;
 
             if (countGood != null)
             {
@@ -69,8 +67,8 @@ namespace PerformanceCalculator.Simulate
 
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Great, countGreat },
-                { HitResult.Ok, (int)countGood },
+                { HitResult.Great, countGreat ?? 0 },
+                { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, countMiss }
             };

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -67,8 +67,8 @@ namespace PerformanceCalculator.Simulate
 
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Great, countGreat ?? 0 },
-                { HitResult.Ok, countGood ?? 0 },
+                { HitResult.Great, (int)countGreat },
+                { HitResult.Ok, (int)countGood },
                 { HitResult.Meh, 0 },
                 { HitResult.Miss, countMiss }
             };

--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -223,10 +223,10 @@ namespace PerformanceCalculatorGUI
                 //
                 // total = ((1/6) * meh + (1/3) * ok + (2/3) * good + great + perfect) / acc
                 // total = miss + meh + ok + good + great + perfect
-                // 
+                //
                 // miss + (5/6) * meh + (2/3) * ok + (1/3) * good = total - acc * total
                 // meh = 1.2 * (total - acc * total) - 1.2 * miss - 0.8 * ok - 0.4 * good
-                countMeh = (int)Math.Round(1.2 * (totalHits - totalHits * accuracy) - 1.2 * countMiss - 0.8 * (countOk ?? 0) - 0.4 * (countGood ?? 0));
+                countMeh = (int)Math.Round((1.2 * (totalHits - totalHits * accuracy)) - (1.2 * countMiss) - (0.8 * (countOk ?? 0)) - (0.4 * (countGood ?? 0)));
             }
 
             // We need to clamp for all values because performance calculator's custom accuracy formula is not invariant to negative counts.

--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -229,7 +229,7 @@ namespace PerformanceCalculatorGUI
             // We need to clamp for all values because performance calculator's custom accuracy formula is not invariant to negative counts.
             int currentCounts = countMiss;
 
-            countMeh = Math.Clamp(countMeh ?? 0, 0, totalHits - currentCounts);
+            countMeh = Math.Clamp((int)countMeh, 0, totalHits - currentCounts);
             currentCounts += (int)countMeh;
 
             countOk = Math.Clamp(countOk ?? 0, 0, totalHits - currentCounts);
@@ -245,10 +245,10 @@ namespace PerformanceCalculatorGUI
             return new Dictionary<HitResult, int>
             {
                 { HitResult.Perfect, countPerfect },
-                { HitResult.Great, countGreat ?? 0 },
-                { HitResult.Ok, countOk ?? 0 },
-                { HitResult.Good, countGood ?? 0 },
-                { HitResult.Meh, countMeh ?? 0 },
+                { HitResult.Great, (int)countGreat },
+                { HitResult.Ok, (int)countOk },
+                { HitResult.Good, (int)countGood },
+                { HitResult.Meh, (int)countMeh },
                 { HitResult.Miss, countMiss }
             };
         }

--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -216,34 +216,31 @@ namespace PerformanceCalculatorGUI
 
             countMiss = Math.Clamp(countMiss, 0, totalHits);
 
-            if (countMeh == null)
-            {
-                // Populate score with mehs to make this approximation more precise.
-                // This value can be negative on impossible misscount.
-                //
-                // total = ((1/6) * meh + (1/3) * ok + (2/3) * good + great + perfect) / acc
-                // total = miss + meh + ok + good + great + perfect
-                //
-                // miss + (5/6) * meh + (2/3) * ok + (1/3) * good = total - acc * total
-                // meh = 1.2 * (total - acc * total) - 1.2 * miss - 0.8 * ok - 0.4 * good
-                countMeh = (int)Math.Round((1.2 * (totalHits - totalHits * accuracy)) - (1.2 * countMiss) - (0.8 * (countOk ?? 0)) - (0.4 * (countGood ?? 0)));
-            }
+            // Populate score with mehs to make this approximation more precise.
+            // This value can be negative on impossible misscount.
+            //
+            // total = ((1/6) * meh + (1/3) * ok + (2/3) * good + great + perfect) / acc
+            // total = miss + meh + ok + good + great + perfect
+            //
+            // miss + (5/6) * meh + (2/3) * ok + (1/3) * good = total - acc * total
+            // meh = 1.2 * (total - acc * total) - 1.2 * miss - 0.8 * ok - 0.4 * good
+            countMeh ??= (int)Math.Round((1.2 * (totalHits - totalHits * accuracy)) - (1.2 * countMiss) - (0.8 * (countOk ?? 0)) - (0.4 * (countGood ?? 0)));
 
             // We need to clamp for all values because performance calculator's custom accuracy formula is not invariant to negative counts.
             int currentCounts = countMiss;
 
             countMeh = Math.Clamp(countMeh ?? 0, 0, totalHits - currentCounts);
-            currentCounts += countMeh ?? 0;
+            currentCounts += (int)countMeh;
 
             countOk = Math.Clamp(countOk ?? 0, 0, totalHits - currentCounts);
-            currentCounts += countOk ?? 0;
+            currentCounts += (int)countOk;
 
             countGood = Math.Clamp(countGood ?? 0, 0, totalHits - currentCounts);
-            currentCounts += countGood ?? 0;
+            currentCounts += (int)countGood;
 
             countGreat = Math.Clamp(countGreat ?? 0, 0, totalHits - currentCounts);
 
-            int countPerfect = totalHits - (countGreat ?? 0) - (countGood ?? 0) - (countOk ?? 0) - (countMeh ?? 0) - countMiss;
+            int countPerfect = totalHits - (int)countGreat - (int)countGood - (int)countOk - (int)countMeh - countMiss;
 
             return new Dictionary<HitResult, int>
             {

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -729,16 +729,27 @@ namespace PerformanceCalculatorGUI.Screens
             }
         }
 
-        private void updateAccuracyParams(bool useFullScoreData)
+        private void resetTextBoxes()
         {
+            greatsTextBox.Text = string.Empty;
+            greatsTextBox.Value.Value = 0;
+
             goodsTextBox.Text = string.Empty;
             goodsTextBox.Value.Value = 0;
+
+            oksTextBox.Text = string.Empty;
+            oksTextBox.Value.Value = 0;
 
             mehsTextBox.Text = string.Empty;
             mehsTextBox.Value.Value = 0;
 
             accuracyTextBox.Text = string.Empty;
             accuracyTextBox.Value.Value = 100;
+        }
+
+        private void updateAccuracyParams(bool useFullScoreData)
+        {
+            resetTextBoxes();
 
             if (useFullScoreData)
             {


### PR DESCRIPTION
Since osu!mania now uses accuracy -> pp system instead of score -> pp, mania score simulation needs to be updated in both osu-tools and osu-tools GUI. However, i heard that you want to revert this change so idk if this pull request is still relevant or not.