### PR TITLE
Update game packages (and fix compile failures)

### DIFF
--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Alba.CsConsoleFormat" Version="1.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.2" />
-    <PackageReference Include="ppy.osu.Game" Version="2023.326.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.326.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.326.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.326.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.326.1" />
+    <PackageReference Include="ppy.osu.Game" Version="2023.605.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.605.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.605.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.605.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.605.0" />
   </ItemGroup>
 </Project>

--- a/PerformanceCalculatorGUI/PerformanceCalculatorGUI.csproj
+++ b/PerformanceCalculatorGUI/PerformanceCalculatorGUI.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2023.326.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.326.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.326.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.326.1" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.326.1" />
+    <PackageReference Include="ppy.osu.Game" Version="2023.605.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.605.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.605.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.605.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.605.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I'm bothering to do this because the game-side ScoreV2 changes break local checkout in this project too.

The place this breaks is quite weird. Previously, the performance calculator GUI, whenever faced with a beatmap that didn't have any scores, would just make up scores on the spot, by generating hit statistics and computing everything from that.

With the game-side switch to ScoreV2, this is no longer feasible. In particular, in ScoreV2, the _order_ of the incoming judgements matters (due to the combo locality property of it). Which means that in order to generate a proper score for the fake statistics data, the fake score has to be generated _judgement by judgement_.

This functionality is way too finicky and complicated to bring back, and the end result is likely to be useless. So I just trim it entirely and display a placeholder instead.