### PR TITLE
Export mod labels and descriptions

### DIFF
--- a/PerformanceCalculator/Difficulty/ModsCommand.cs
+++ b/PerformanceCalculator/Difficulty/ModsCommand.cs
@@ -63,7 +63,7 @@ namespace PerformanceCalculator.Difficulty
             {
                 var sourceProperties = mod.GetSettingsSourceProperties();
 
-                foreach (var (_, propertyInfo) in sourceProperties)
+                foreach (var (settingsSource, propertyInfo) in sourceProperties)
                 {
                     var bindable = propertyInfo.GetValue(mod);
 
@@ -75,7 +75,9 @@ namespace PerformanceCalculator.Difficulty
                     yield return new
                     {
                         Name = propertyInfo.Name.Underscore(),
-                        Type = getJsonType(netType)
+                        Type = getJsonType(netType),
+                        Label = settingsSource.Label.ToString(),
+                        Description = settingsSource.Description.ToString(),
                     };
                 }
             }


### PR DESCRIPTION
To be used for https://github.com/ppy/osu-web/issues/10471.

Not considering localisations yet as we haven't localised any. It will require further thought (`osu-client` strings will need to be exported back to `osu-web` for the first time ever).

Of note, we need to somehow make custom tooltips exportable in the future (the raw format part aka https://github.com/ppy/osu/blob/1f9f2b413e2218bc6353ffc496c319f35eb7ea96/osu.Game/Rulesets/Mods/ModRateAdjust.cs#L30), but that's for another day.

![iTerm2 2023-08-23 at 10 12 42](https://github.com/ppy/osu-tools/assets/191335/fc76f161-bbd2-45a2-9c92-67e650698d39)
