### PR TITLE
Fix incorrect difficulty adjustment mods for converted beatmaps

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -126,7 +126,7 @@ namespace PerformanceCalculator.Difficulty
         {
             // Get the ruleset
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.Ruleset.OnlineID);
-            var mods = NoClassicMod ? getMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, getMods(ruleset));
+            var mods = NoClassicMod ? getMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(beatmap.BeatmapInfo, ruleset, getMods(ruleset));
             var attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(mods);
 
             return new Result

--- a/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
+++ b/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
@@ -61,7 +61,7 @@ namespace PerformanceCalculator.Leaderboard
                     var score = new ProcessorScoreDecoder(working).Parse(scoreInfo);
 
                     var difficultyCalculator = ruleset.CreateDifficultyCalculator(working);
-                    var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, scoreInfo.Mods).ToArray());
+                    var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(working.BeatmapInfo, ruleset, scoreInfo.Mods).ToArray());
                     var performanceCalculator = ruleset.CreatePerformanceCalculator();
 
                     plays.Add((performanceCalculator?.Calculate(score.ScoreInfo, difficultyAttributes).Total ?? 0, play.PP ?? 0.0));

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -67,21 +67,12 @@ namespace PerformanceCalculator
         /// Transforms a given <see cref="Mod"/> combination into one which is applicable to legacy scores.
         /// This is used to match osu!stable/osu!web calculations for the time being, until such a point that these mods do get considered.
         /// </summary>
-        public static Mod[] ConvertToLegacyDifficultyAdjustmentMods(Ruleset ruleset, Mod[] mods)
+        public static Mod[] ConvertToLegacyDifficultyAdjustmentMods(BeatmapInfo beatmapInfo, Ruleset ruleset, Mod[] mods)
         {
-            var beatmap = new EmptyWorkingBeatmap
-            {
-                BeatmapInfo =
-                {
-                    Ruleset = ruleset.RulesetInfo,
-                    Difficulty = new BeatmapDifficulty()
-                }
-            };
-
             var allMods = ruleset.CreateAllMods().ToArray();
 
             var allowedMods = ModUtils.FlattenMods(
-                                          ruleset.CreateDifficultyCalculator(beatmap).CreateDifficultyAdjustmentModCombinations())
+                                          ruleset.CreateDifficultyCalculator(new EmptyWorkingBeatmap(beatmapInfo)).CreateDifficultyAdjustmentModCombinations())
                                       .Select(m => m.GetType())
                                       .Distinct()
                                       .ToHashSet();
@@ -103,8 +94,8 @@ namespace PerformanceCalculator
 
         private class EmptyWorkingBeatmap : WorkingBeatmap
         {
-            public EmptyWorkingBeatmap()
-                : base(new BeatmapInfo(), null)
+            public EmptyWorkingBeatmap(BeatmapInfo beatmapInfo)
+                : base(beatmapInfo, null)
             {
             }
 

--- a/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
@@ -38,7 +38,7 @@ namespace PerformanceCalculator.Performance
 
             Mod[] mods = score.ScoreInfo.Mods;
             if (score.ScoreInfo.IsLegacyScore)
-                mods = LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, mods);
+                mods = LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(workingBeatmap.BeatmapInfo, ruleset, mods);
 
             var difficultyAttributes = difficultyCalculator.Calculate(mods);
             var performanceCalculator = score.ScoreInfo.Ruleset.CreateInstance().CreatePerformanceCalculator();

--- a/PerformanceCalculator/Performance/ScorePerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/ScorePerformanceCommand.cs
@@ -40,7 +40,7 @@ namespace PerformanceCalculator.Performance
 
             var workingBeatmap = ProcessorWorkingBeatmap.FromFileOrId(score.BeatmapInfo!.OnlineID.ToString());
             var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
-            var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, score.Mods));
+            var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(workingBeatmap.BeatmapInfo, ruleset, score.Mods));
             var performanceCalculator = ruleset.CreatePerformanceCalculator();
             var performanceAttributes = performanceCalculator?.Calculate(score, difficultyAttributes);
 

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -52,7 +52,7 @@ namespace PerformanceCalculator.Profile
                 var score = new ProcessorScoreDecoder(working).Parse(scoreInfo);
 
                 var difficultyCalculator = ruleset.CreateDifficultyCalculator(working);
-                var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, scoreInfo.Mods).ToArray());
+                var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(working.BeatmapInfo, ruleset, scoreInfo.Mods).ToArray());
                 var performanceCalculator = ruleset.CreatePerformanceCalculator();
 
                 var ppAttributes = performanceCalculator?.Calculate(score.ScoreInfo, difficultyAttributes);

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -56,8 +56,8 @@ namespace PerformanceCalculator.Simulate
         {
             var ruleset = Ruleset;
 
-            var mods = NoClassicMod ? GetMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(ruleset, GetMods(ruleset));
             var workingBeatmap = ProcessorWorkingBeatmap.FromFileOrId(Beatmap);
+            var mods = NoClassicMod ? GetMods(ruleset) : LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(workingBeatmap.BeatmapInfo, ruleset, GetMods(ruleset));
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
 
             var beatmapMaxCombo = GetMaxCombo(beatmap);


### PR DESCRIPTION
`ManiaDifficultyCalculator` allows different mods depending on whether the beatmap is a convert or not:

https://github.com/ppy/osu/blob/d701a2596985d497096a6e85d0585456cdbfd553/osu.Game.Rulesets.Mania/Difficulty/ManiaDifficultyCalculator.cs#L105-L139

The code in `LegacyHelper` is used to filter the incoming mods to only those that adjust difficulty, so it needs to have the correct ruleset set for `ManiaDifficultyCalculator` to work correctly - the one that corresponds to the beatmap rather than the one for the incoming score/target ruleset.