### PR TITLE
Fix PP not being calculated correctly for nightcore scores

### DIFF
--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -78,7 +78,7 @@ namespace PerformanceCalculator
                                       .ToHashSet();
 
             // Special case to allow either DT or NC.
-            if (mods.Any(m => m is ModDoubleTime))
+            if (allowedMods.Any(type => type.IsSubclassOf(typeof(ModDoubleTime))) && mods.Any(m => m is ModNightcore))
                 allowedMods.Add(allMods.Single(m => m is ModNightcore).GetType());
 
             var result = new List<Mod>();

--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -49,7 +49,7 @@ namespace PerformanceCalculatorGUI
                                       .ToHashSet();
 
             // Special case to allow either DT or NC.
-            if (mods.Any(m => m is ModDoubleTime))
+            if (allowedMods.Any(type => type.IsSubclassOf(typeof(ModDoubleTime))) && mods.Any(m => m is ModNightcore))
                 allowedMods.Add(allMods.Single(m => m is ModNightcore).GetType());
 
             var result = new List<Mod>();


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/25175

I guess this would be one way to roll forward with https://github.com/ppy/osu/pull/24640, but there is a chance something somewhere else could have relied on the inheritance and might now break, so not sure whether this should be the solution here...

Check is slightly rewritten since it wasn't making much sense to me previously (why add nightcore to allowed mods if double time is selected?)