### PR TITLE
Update mania simulate command to accept hit result counts

### DIFF
--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -10,7 +10,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mania.Objects;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 
 namespace PerformanceCalculator.Simulate

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -4,11 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mania;
+using osu.Game.Rulesets.Mania.Objects;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 
@@ -29,6 +31,31 @@ namespace PerformanceCalculator.Simulate
         [UsedImplicitly]
         [Option(Template = "-s|--score <score>", Description = "Score. An integer 0-1000000.")]
         private int? score { get; set; }
+
+        [UsedImplicitly]
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
+                                                                     + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
+        public override double Accuracy { get; } = 100;
+
+        [UsedImplicitly]
+        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
+        public override int Misses { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-M|--mehs <mehs>", Description = "Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Mehs { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-O|--oks <oks>", Description = "Number of oks. Will override accuracy if used. Otherwise is automatically calculated.")]
+        private int? oks { get; set; }
+
+        [UsedImplicitly]
+        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Goods { get; }
+
+        [UsedImplicitly]
+        [Option(Template = "-T|--greats <greats>", Description = "Number of greats. Will override accuracy if used. Otherwise is automatically calculated.")]
+        private int? greats { get; set; }
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
@@ -60,17 +87,58 @@ namespace PerformanceCalculator.Simulate
 
         protected override Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
         {
-            var totalHits = beatmap.HitObjects.Count;
+            // One judgement per normal note. Two judgements per hold note (head + tail).
+            var totalHits = beatmap.HitObjects.Count + beatmap.HitObjects.Count(ho => ho is HoldNote);
 
-            // Only total number of hits is considered currently, so specifics don't matter
+            if (countMeh != null || oks != null || countGood != null || greats != null)
+            {
+                int countPerfect = totalHits - (countMiss + (countMeh ?? 0) + (oks ?? 0) + (countGood ?? 0) + (greats ?? 0));
+
+                return new Dictionary<HitResult, int>
+                {
+                    [HitResult.Perfect] = countPerfect,
+                    [HitResult.Great] = greats ?? 0,
+                    [HitResult.Good] = countGood ?? 0,
+                    [HitResult.Ok] = oks ?? 0,
+                    [HitResult.Meh] = countMeh ?? 0,
+                    [HitResult.Miss] = countMiss
+                };
+            }
+
+            // Let Great=Perfect=6, Good=4, Ok=2, Meh=1, Miss=0. The total should be this.
+            var targetTotal = (int)Math.Round(accuracy * totalHits * 6);
+
+            // Start by assuming every non miss is a meh
+            // This is how much increase is needed by the rest
+            int remainingHits = totalHits - countMiss;
+            int delta = targetTotal - remainingHits;
+
+            // Each great and perfect increases total by 5 (great-meh=5)
+            // There is no difference in accuracy between them, so just halve arbitrarily.
+            greats = Math.Min(delta / 5, remainingHits) / 2;
+            int perfects = greats.Value;
+            delta -= (greats.Value + perfects) * 5;
+            remainingHits -= (greats.Value + perfects);
+
+            // Each good increases total by 3 (good-meh=3).
+            countGood = Math.Min(delta / 3, remainingHits);
+            delta -= countGood.Value * 3;
+            remainingHits -= countGood.Value;
+
+            // Each ok increases total by 1 (ok-meh=1).
+            oks = delta;
+
+            // Everything else is a meh, as initially assumed.
+            countMeh = remainingHits;
+
             return new Dictionary<HitResult, int>
             {
-                { HitResult.Perfect, totalHits },
-                { HitResult.Great, 0 },
-                { HitResult.Ok, 0 },
-                { HitResult.Good, 0 },
-                { HitResult.Meh, 0 },
-                { HitResult.Miss, 0 }
+                { HitResult.Perfect, perfects },
+                { HitResult.Great, greats.Value },
+                { HitResult.Ok, oks.Value },
+                { HitResult.Good, countGood.Value },
+                { HitResult.Meh, countMeh.Value },
+                { HitResult.Miss, countMiss }
             };
         }
     }

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
@@ -19,19 +18,6 @@ namespace PerformanceCalculator.Simulate
     [Command(Name = "mania", Description = "Computes the performance (pp) of a simulated osu!mania play.")]
     public class ManiaSimulateCommand : SimulateCommand
     {
-        public override int Score
-        {
-            get
-            {
-                Debug.Assert(score != null);
-                return score.Value;
-            }
-        }
-
-        [UsedImplicitly]
-        [Option(Template = "-s|--score <score>", Description = "Score. An integer 0-1000000.")]
-        private int? score { get; set; }
-
         [UsedImplicitly]
         [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
                                                                      + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
@@ -63,25 +49,6 @@ namespace PerformanceCalculator.Simulate
         public override string[] Mods { get; }
 
         public override Ruleset Ruleset => new ManiaRuleset();
-
-        public override void Execute()
-        {
-            if (score == null)
-            {
-                double scoreMultiplier = 1;
-
-                // Cap score depending on difficulty adjustment mods (matters for mania).
-                foreach (var mod in GetMods(Ruleset))
-                {
-                    if (mod.Type == ModType.DifficultyReduction)
-                        scoreMultiplier *= mod.ScoreMultiplier;
-                }
-
-                score = (int)Math.Round(1000000 * scoreMultiplier);
-            }
-
-            base.Execute();
-        }
 
         protected override int GetMaxCombo(IBeatmap beatmap) => 0;
 


### PR DESCRIPTION
Found while investigating https://github.com/ppy/osu/issues/25719. I wanted to confirm what the reporter was saying about the PP numbers reported being for nomod rather than daycore, and proceeded to find that mania simulate would return entirely different numbers.

Score has not been used for performance calculation since https://github.com/ppy/osu/pull/18749, so the current code's assertion that "only total number of hits is considered currently" is no longer correct.

The "hit statistics from accuracy" approximation thing is very loose and not intended to really be that useful, but it should *technically* yield the expected accuracy value (there are multiple possible solutions, this just finds one of them). I don't think that function is particularly useful or accurate in any ruleset anyhow.