### PR TITLE
Update game packages & fix compilation failures

### DIFF
--- a/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
@@ -44,7 +44,7 @@ namespace PerformanceCalculator.Performance
             {
                 difficultyMods = LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(workingBeatmap.BeatmapInfo, ruleset, difficultyMods);
                 score.ScoreInfo.LegacyTotalScore = (int)score.ScoreInfo.TotalScore;
-                score.ScoreInfo.TotalScore = StandardisedScoreMigrationTools.ConvertFromLegacyTotalScore(
+                StandardisedScoreMigrationTools.UpdateFromLegacy(
                     score.ScoreInfo,
                     LegacyBeatmapConversionDifficultyInfo.FromBeatmap(playableBeatmap),
                     ((ILegacyRuleset)ruleset).CreateLegacyScoreSimulator().Simulate(workingBeatmap, playableBeatmap));

--- a/PerformanceCalculator/Performance/ScorePerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/ScorePerformanceCommand.cs
@@ -46,7 +46,7 @@ namespace PerformanceCalculator.Performance
                 score.Mods = score.Mods.Append(ruleset.CreateMod<ModClassic>()).ToArray();
                 score.IsLegacyScore = true;
                 score.LegacyTotalScore = (int)score.TotalScore;
-                score.TotalScore = StandardisedScoreMigrationTools.ConvertFromLegacyTotalScore(
+                StandardisedScoreMigrationTools.UpdateFromLegacy(
                     score,
                     LegacyBeatmapConversionDifficultyInfo.FromAPIBeatmap(apiBeatmap),
                     ((ILegacyRuleset)ruleset).CreateLegacyScoreSimulator().Simulate(workingBeatmap, workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, score.Mods)));

--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Alba.CsConsoleFormat" Version="1.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
-    <PackageReference Include="ppy.osu.Game" Version="2023.1114.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1114.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1114.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1114.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1114.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2023.1224.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1224.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1224.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1224.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1224.0" />
   </ItemGroup>
 </Project>

--- a/PerformanceCalculatorGUI/PerformanceCalculatorGUI.csproj
+++ b/PerformanceCalculatorGUI/PerformanceCalculatorGUI.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2023.1114.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1114.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1114.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1114.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1114.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2023.1224.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2023.1224.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2023.1224.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2023.1224.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2023.1224.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Needed for https://github.com/ppy/osu/issues/26186.

Basically what happened is that the making-private of `StandardisedScoreMigrationTools.ConvertFromLegacyTotalScore()` caused the "update mods definition" workflow to [start failing](https://github.com/ppy/osu/actions/workflows/update-web-mod-definitions.yml), which is why web has not been receiving mod definition updates for the past couple of releases.