### PR TITLE
Update readme after .NET 8 bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ This is part of a group of projects which are used in live deployments where the
 
 # Requirements
 
-- A desktop platform with the [.NET 6.0 SDK](https://dotnet.microsoft.com/download) installed.
+- A desktop platform with the [.NET 8.0 SDK](https://dotnet.microsoft.com/download) installed.
 - When working with the codebase, we recommend using an IDE with intelligent code completion and syntax highlighting, such as the latest version of [Visual Studio](https://visualstudio.microsoft.com/vs/), [JetBrains Rider](https://www.jetbrains.com/rider/) or [Visual Studio Code](https://code.visualstudio.com/).
 - These instructions assume you have the the [CLI git client](https://git-scm.com/) installed, but any other GUI client such as GitKraken will suffice.
-- Note that there are **[additional requirements for Windows 7 and Windows 8.1](https://docs.microsoft.com/en-us/dotnet/core/install/windows?tabs=net60#dependencies)** which you may need to manually install if your operating system is not up-to-date.
 
 # Getting Started
 


### PR DESCRIPTION
Removed the snippet about additional requirements because .NET 8 does not support windows 7 or 8.1 anymore.