### PR TITLE
Update VS Code configuration to point to `net8.0` directory

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/PerformanceCalculator/bin/Debug/net5.0/PerformanceCalculator.dll",
+                "${workspaceRoot}/PerformanceCalculator/bin/Debug/net8.0/PerformanceCalculator.dll",
                 "place-your-arguments-here (launch.json)"
             ],
             "cwd": "${workspaceRoot}",
@@ -21,7 +21,7 @@
             "request": "launch",
             "program": "dotnet",
             "args": [
-                "${workspaceRoot}/PerformanceCalculator/bin/Release/net5.0/PerformanceCalculator.dll",
+                "${workspaceRoot}/PerformanceCalculator/bin/Release/net8.0/PerformanceCalculator.dll",
                 "place-your-arguments-here (launch.json)"
             ],
             "cwd": "${workspaceRoot}",


### PR DESCRIPTION
Don't know if anyone is using it but might as well update it if it's around.