### PR TITLE
Fix maxFruits count

### DIFF
--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -58,7 +58,7 @@ namespace PerformanceCalculator.Simulate
             var maxCombo = GetMaxCombo(beatmap);
             int maxTinyDroplets = beatmap.HitObjects.OfType<JuiceStream>().Sum(s => s.NestedHitObjects.OfType<TinyDroplet>().Count());
             int maxDroplets = beatmap.HitObjects.OfType<JuiceStream>().Sum(s => s.NestedHitObjects.OfType<Droplet>().Count()) - maxTinyDroplets;
-            int maxFruits = beatmap.HitObjects.OfType<Fruit>().Count() + 2 * beatmap.HitObjects.OfType<JuiceStream>().Count() + beatmap.HitObjects.OfType<JuiceStream>().Sum(s => s.RepeatCount);
+            int maxFruits = beatmap.HitObjects.Sum(h => h is Fruit ? 1 : (h as JuiceStream)?.NestedHitObjects.Count(n => n is Fruit) ?? 0);
 
             // Either given or max value minus misses
             int countDroplets = countGood ?? Math.Max(0, maxDroplets - countMiss);


### PR DESCRIPTION
Generating hitresults on the converted catch map [/b/1151178](https://osu.ppy.sh/beatmapsets/217667#fruits/1151178) resulted in incorrect values
```
great               : 634
largetickhit        : 0
smalltickhit        : 313
smalltickmiss       : 8
miss                : 0
```

This PR counts fruits within juicestreams correctly
```
great               : 626
largetickhit        : 0
smalltickhit        : 321
smalltickmiss       : 0
miss                : 0
```

![image](https://github.com/ppy/osu-tools/assets/41148446/97bf7b98-0663-458a-ae67-bc677849cb92)
