### PR TITLE
Fix mania GenerateHitResults() bugs

### DIFF
--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -80,11 +80,12 @@ namespace PerformanceCalculator.Simulate
             int delta = targetTotal - remainingHits;
 
             // Each great and perfect increases total by 5 (great-meh=5)
-            // There is no difference in accuracy between them, so just halve arbitrarily.
-            greats = Math.Min(delta / 5, remainingHits) / 2;
-            int perfects = greats.Value;
+            // There is no difference in accuracy between them, so just halve arbitrarily (favouring perfects for an odd number).
+            int greatsAndPerfects = Math.Min(delta / 5, remainingHits);
+            greats = greatsAndPerfects / 2;
+            int perfects = greats.Value + greatsAndPerfects % 2;
             delta -= (greats.Value + perfects) * 5;
-            remainingHits -= (greats.Value + perfects);
+            remainingHits -= greats.Value + perfects;
 
             // Each good increases total by 3 (good-meh=3).
             countGood = Math.Min(delta / 3, remainingHits);
@@ -93,6 +94,7 @@ namespace PerformanceCalculator.Simulate
 
             // Each ok increases total by 1 (ok-meh=1).
             oks = delta;
+            remainingHits -= oks.Value;
 
             // Everything else is a meh, as initially assumed.
             countMeh = remainingHits;

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -83,7 +83,7 @@ namespace PerformanceCalculator.Simulate
             // There is no difference in accuracy between them, so just halve arbitrarily (favouring perfects for an odd number).
             int greatsAndPerfects = Math.Min(delta / 5, remainingHits);
             greats = greatsAndPerfects / 2;
-            int perfects = greats.Value + (greatsAndPerfects % 2);
+            int perfects = greatsAndPerfects - greats.Value;
             delta -= (greats.Value + perfects) * 5;
             remainingHits -= greats.Value + perfects;
 

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -83,7 +83,7 @@ namespace PerformanceCalculator.Simulate
             // There is no difference in accuracy between them, so just halve arbitrarily (favouring perfects for an odd number).
             int greatsAndPerfects = Math.Min(delta / 5, remainingHits);
             greats = greatsAndPerfects / 2;
-            int perfects = greats.Value + greatsAndPerfects % 2;
+            int perfects = greats.Value + (greatsAndPerfects % 2);
             delta -= (greats.Value + perfects) * 5;
             remainingHits -= greats.Value + perfects;
 


### PR DESCRIPTION
There are a couple bugs:

1. An odd number of `Perfect`/`Great` hits would miss a hit and throw off following calculations.
2. `Ok`s were duplicated as `Meh`s

This function is quite hard to parse so it's not surprising these slipped in.
I think these variables could do with some renaming, but that's beyond the scope of this fix.

On a side note, my gut says it should just assume all `Great`s are `Perfect`s rather than splitting them down the middle.
Usually one would expect that omitting a parameter would set it as the best possible value.