### PR TITLE
Fix `performance legacy-score` command doing things it doesn't need to

### DIFF
--- a/PerformanceCalculator/Performance/LegacyScorePerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/LegacyScorePerformanceCommand.cs
@@ -1,13 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Linq;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
@@ -26,9 +24,6 @@ namespace PerformanceCalculator.Performance
         {
             var score = base.CreateScore(apiScore, ruleset, apiBeatmap, workingBeatmap);
 
-            score.Mods = score.Mods.Append(ruleset.CreateMod<ModClassic>()).ToArray();
-            score.IsLegacyScore = true;
-            score.LegacyTotalScore = (int)score.TotalScore;
             LegacyScoreDecoder.PopulateMaximumStatistics(score, workingBeatmap);
             StandardisedScoreMigrationTools.UpdateFromLegacy(
                 score,


### PR DESCRIPTION
I'm not exactly sure when or how this happened because I tested this previously (did some web change cause this?), but the `performance legacy-score` command is:

- doubly-applying the classic mod
- needlessly marking the score as legacy
- incorrectly copying the post-conversion recalculated total score into `LegacyTotalScore`

while all it needs to be doing is reading what it is given from the API. All of the data it needs is already there, in a form ready for consumption.

For instance, see output of `performance legacy-score 215127587 2` ([see relevant score](https://osu.ppy.sh/scores/catch/215127587)):

<details>
<summary>master</summary>

```
Basic score info
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
beatmap             : 2062131 - Ricky Montgomery - Snow (Crowley)
total score         : 1071818
legacy total score  : 1117705
accuracy            : 99.37
combo               : 1015
mods                : DT, HD, CL, CL

Hit statistics
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
great               : 985
largetickhit        : 30
smalltickhit        : 867
smalltickmiss       : 12

Performance attributes
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
pp                  : 373.07

Difficulty attributes
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
star rating         : 5.49
max combo           : 1,015.00
approach rate       : 9.87
```

</details>

<details>
<summary>this PR</summary>

```
Basic score info
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
beatmap             : 2062131 - Ricky Montgomery - Snow (Crowley)
total score         : 1117518
legacy total score  : 33334515
accuracy            : 99.37
combo               : 1015
mods                : DT, HD, CL

Hit statistics
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
great               : 985
largetickhit        : 30
smalltickhit        : 867
smalltickmiss       : 12

Performance attributes
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
pp                  : 373.07

Difficulty attributes
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
star rating         : 5.49
max combo           : 1,015.00
approach rate       : 9.87
```

</details>
