### PR TITLE
Fix GUI object inspectors, update packages

### DIFF
--- a/PerformanceCalculatorGUI/Components/StrainVisualizer.cs
+++ b/PerformanceCalculatorGUI/Components/StrainVisualizer.cs
@@ -97,7 +97,7 @@ namespace PerformanceCalculatorGUI.Components
         {
             graphsContainer.Clear();
 
-            var skills = val.NewValue.Where(x => x is StrainSkill).ToArray();
+            var skills = val.NewValue.Where(x => x is StrainSkill or StrainDecaySkill).ToArray();
 
             // dont bother if there are no strain skills to draw
             if (skills.Length == 0)

--- a/PerformanceCalculatorGUI/Components/TextBoxes/FileChooserLabelledTextBox.cs
+++ b/PerformanceCalculatorGUI/Components/TextBoxes/FileChooserLabelledTextBox.cs
@@ -101,7 +101,7 @@ namespace PerformanceCalculatorGUI.Components.TextBoxes
                 OnFocused?.Invoke();
                 base.OnFocus(e);
 
-                GetContainingInputManager().TriggerFocusContention(this);
+                GetContainingFocusManager()?.TriggerFocusContention(this);
             }
         }
 

--- a/PerformanceCalculatorGUI/Components/TextBoxes/LimitedLabelledFractionalNumberBox.cs
+++ b/PerformanceCalculatorGUI/Components/TextBoxes/LimitedLabelledFractionalNumberBox.cs
@@ -14,7 +14,7 @@ namespace PerformanceCalculatorGUI.Components.TextBoxes
         {
             protected override bool AllowIme => false;
 
-            protected override bool CanAddCharacter(char character) => character.IsAsciiDigit() || character == CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator[0];
+            protected override bool CanAddCharacter(char character) => char.IsAsciiDigit(character) || character == CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator[0];
 
             protected override void OnUserTextAdded(string added)
             {

--- a/PerformanceCalculatorGUI/Components/TextBoxes/LimitedLabelledFractionalNumberBox.cs
+++ b/PerformanceCalculatorGUI/Components/TextBoxes/LimitedLabelledFractionalNumberBox.cs
@@ -3,7 +3,6 @@
 
 using System.Globalization;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions;
 using osu.Game.Graphics.UserInterface;
 
 namespace PerformanceCalculatorGUI.Components.TextBoxes

--- a/PerformanceCalculatorGUI/PerformanceCalculatorGUI.csproj
+++ b/PerformanceCalculatorGUI/PerformanceCalculatorGUI.csproj
@@ -6,10 +6,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2024.130.2" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.130.2" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.130.2" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.130.2" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.130.2" />
+    <PackageReference Include="ppy.osu.Game" Version="2024.625.2" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.625.2" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.625.2" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.625.2" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.625.2" />
   </ItemGroup>
 </Project>

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/CatchObjectInspectorRuleset.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/CatchObjectInspectorRuleset.cs
@@ -4,21 +4,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Game.Beatmaps;
-using osu.Game.Graphics;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Catch.Edit;
-using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.UI;
 
 namespace PerformanceCalculatorGUI.Screens.ObjectInspection
 {
-    public partial class CatchObjectInspectorRuleset : DrawableCatchRuleset
+    public partial class CatchObjectInspectorRuleset : DrawableCatchEditorRuleset
     {
         private readonly CatchDifficultyHitObject[] difficultyHitObjects;
 
@@ -36,36 +30,12 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
 
         public override bool PropagateNonPositionalInputSubTree => false;
 
-        protected override Playfield CreatePlayfield() => new CatchObjectInspectorPlayfield(Beatmap.Difficulty);
+        public override bool AllowBackwardsSeeks => true;
 
         protected override void Update()
         {
             base.Update();
             objectDifficultyValuesContainer.CurrentDifficultyHitObject.Value = difficultyHitObjects.LastOrDefault(x => x.StartTime < Clock.CurrentTime);
-        }
-
-        private partial class CatchObjectInspectorPlayfield : CatchEditorPlayfield
-        {
-            protected override GameplayCursorContainer CreateCursor() => null!;
-
-            public CatchObjectInspectorPlayfield(IBeatmapDifficultyInfo difficulty)
-                : base(difficulty)
-            {
-                DisplayJudgements.Value = false;
-                AddInternal(new Container
-                {
-                    RelativeSizeAxes = Axes.X,
-                    Y = 440,
-                    Height = 6.0f,
-                    CornerRadius = 4.0f,
-                    Masking = true,
-                    Child = new Box
-                    {
-                        Colour = OsuColour.Gray(0.5f),
-                        RelativeSizeAxes = Axes.Both
-                    }
-                });
-            }
         }
     }
 }

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/ObjectDifficultyValuesContainer.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/ObjectDifficultyValuesContainer.cs
@@ -132,7 +132,7 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
             });
 
             if (hitObject.Angle is not null)
-                flowContainer.Add(new ObjectInspectorDifficultyValue("Angle", MathUtils.RadiansToDegrees(hitObject.Angle.Value)));
+                flowContainer.Add(new ObjectInspectorDifficultyValue("Angle", double.RadiansToDegrees(hitObject.Angle.Value)));
 
             if (hitObject.BaseObject is Slider)
             {

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/ObjectDifficultyValuesContainer.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/ObjectDifficultyValuesContainer.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Utils;
 using osu.Game.Graphics.Containers;
 using osu.Game.Overlays;
 using osu.Game.Rulesets.Catch.Difficulty.Preprocessing;

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/ObjectInspector.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/ObjectInspector.cs
@@ -178,7 +178,6 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
                 },
                 "taiko" => new TaikoPlayfieldAdjustmentContainer
                 {
-                    RelativeSizeAxes = Axes.Both,
                     Child = new TaikoObjectInspectorRuleset(rulesetInstance, playableBeatmap, modifiedMods, difficultyCalculator.Value as ExtendedTaikoDifficultyCalculator,
                         processorBeatmap.Track.Rate)
                     {

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/OsuObjectInspectorRuleset.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/OsuObjectInspectorRuleset.cs
@@ -10,13 +10,14 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Osu.Edit;
 using osu.Game.Rulesets.Osu.Objects.Drawables;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.UI;
 
 namespace PerformanceCalculatorGUI.Screens.ObjectInspection
 {
-    public partial class OsuObjectInspectorRuleset : DrawableOsuRuleset
+    public partial class OsuObjectInspectorRuleset : DrawableOsuEditorRuleset
     {
         private readonly OsuDifficultyHitObject[] difficultyHitObjects;
 
@@ -39,6 +40,8 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
 
         public override bool PropagateNonPositionalInputSubTree => false;
 
+        public override bool AllowBackwardsSeeks => true;
+
         protected override Playfield CreatePlayfield() => new OsuObjectInspectorPlayfield(difficultyHitObjects);
 
         private partial class OsuObjectInspectorPlayfield : OsuPlayfield
@@ -55,14 +58,12 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
 
             protected override void OnNewDrawableHitObject(DrawableHitObject d)
             {
+                base.OnNewDrawableHitObject(d);
                 d.ApplyCustomUpdateState += updateState;
             }
 
             private void updateState(DrawableHitObject hitObject, ArmedState state)
             {
-                if (state == ArmedState.Idle)
-                    return;
-
                 if (hitObject is DrawableSliderRepeat repeat)
                 {
                     repeat.Arrow.ApplyTransformsAt(hitObject.StateUpdateTime, true);

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/TaikoObjectInspectorRuleset.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/TaikoObjectInspectorRuleset.cs
@@ -8,12 +8,13 @@ using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Taiko.Difficulty.Preprocessing;
+using osu.Game.Rulesets.Taiko.Edit;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
 
 namespace PerformanceCalculatorGUI.Screens.ObjectInspection
 {
-    public partial class TaikoObjectInspectorRuleset : DrawableTaikoRuleset
+    public partial class TaikoObjectInspectorRuleset : DrawableTaikoEditorRuleset
     {
         private readonly TaikoDifficultyHitObject[] difficultyHitObjects;
 
@@ -30,6 +31,8 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
         public override bool PropagatePositionalInputSubTree => false;
 
         public override bool PropagateNonPositionalInputSubTree => false;
+
+        public override bool AllowBackwardsSeeks => true;
 
         protected override Playfield CreatePlayfield() => new TaikoObjectInspectorPlayfield();
 


### PR DESCRIPTION
Turns out GUI's object inspections were broken for some time: 

- osu didn't allow backwards seeking and showed previous object when seeking to object start
- taiko didn't render at all
- catch was weirdly scaled and didn't allow backwards seeking as well