### PR TITLE
Added hidden to relevant mods

### DIFF
--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -67,6 +67,7 @@ namespace PerformanceCalculator
                                            | LegacyMods.Key9 | LegacyMods.KeyCoop;
 
         // See: https://github.com/ppy/osu-queue-score-statistics/blob/2264bfa68e14bb16ec71a7cac2072bdcfaf565b6/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyModsHelper.cs
+        // Since hidden always affects pp calculation, it has been added to the base relevant mods, contrary to the source of this method
         public static LegacyMods MaskRelevantMods(LegacyMods mods, bool isConvertedBeatmap, int rulesetId)
         {
             LegacyMods relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | LegacyMods.Hidden;
@@ -74,10 +75,7 @@ namespace PerformanceCalculator
             switch (rulesetId)
             {
                 case 0:
-                    if ((mods & LegacyMods.Flashlight) > 0)
-                        relevantMods |= LegacyMods.Flashlight | LegacyMods.Hidden | LegacyMods.TouchDevice;
-                    else
-                        relevantMods |= LegacyMods.Flashlight | LegacyMods.TouchDevice;
+                    relevantMods |= LegacyMods.Flashlight | LegacyMods.TouchDevice;
                     break;
 
                 case 3:

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -69,7 +69,7 @@ namespace PerformanceCalculator
         // See: https://github.com/ppy/osu-queue-score-statistics/blob/2264bfa68e14bb16ec71a7cac2072bdcfaf565b6/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyModsHelper.cs
         public static LegacyMods MaskRelevantMods(LegacyMods mods, bool isConvertedBeatmap, int rulesetId)
         {
-            LegacyMods relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy;
+            LegacyMods relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy | LegacyMods.Hidden;
 
             switch (rulesetId)
             {


### PR DESCRIPTION
Fixes hidden not counted as relevant mods when using simulate command without the `-nc` parameter

Before:
![WindowsTerminal_2024-07-20_17-18-01](https://github.com/user-attachments/assets/8e6abc66-ab15-4716-a124-e2ac9616b8fe)

After:
![WindowsTerminal_2024-07-20_17-18-14](https://github.com/user-attachments/assets/16f70616-fd23-4fae-af56-4e1eda82b8da)
