### PR TITLE
Fix lazer mods not being accounted for in Beatmap Leaderboard

### DIFF
--- a/PerformanceCalculatorGUI/Screens/BeatmapLeaderboardScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/BeatmapLeaderboardScreen.cs
@@ -233,7 +233,6 @@ namespace PerformanceCalculatorGUI.Screens
                     var difficultyCalculator = rulesetInstance.CreateDifficultyCalculator(working);
 
                     Mod[] mods = score.Mods.Select(x => x.ToMod(rulesetInstance)).ToArray();
-                    mods = RulesetHelper.ConvertToLegacyDifficultyAdjustmentMods(rulesetInstance, mods);
 
                     var difficultyAttributes = difficultyCalculator.Calculate(mods);
                     var performanceCalculator = rulesetInstance.CreatePerformanceCalculator();


### PR DESCRIPTION
It convers mods to legacy for some reason, what exclude mods like DA