### PR TITLE
Improve object inspection visibility

### DIFF
--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/OsuObjectInspectorRuleset.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/OsuObjectInspectorRuleset.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Drawables;
 using osu.Game.Rulesets.Osu.Difficulty.Preprocessing;
 using osu.Game.Rulesets.Osu.Edit;
@@ -88,7 +89,15 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
                             hitObject.RemoveTransform(existing);
 
                             using (hitObject.BeginAbsoluteSequence(hitObject.StartTimeBindable.Value))
-                                hitObject.Delay(nextHitObject.StartTime - hitObject.StartTimeBindable.Value).FadeOut().Expire();
+                            {
+                                var hitObjectDuration = hitObject.HitObject.GetEndTime() - hitObject.StartTimeBindable.Value;
+
+                                hitObject.Delay(hitObjectDuration)
+                                         .FadeTo(0.25f, 200f, Easing.Out)
+                                         .Delay(nextHitObject.StartTime - hitObject.StartTimeBindable.Value - hitObjectDuration)
+                                         .FadeOut(100f, Easing.Out)
+                                         .Expire();
+                            }
                         }
 
                         break;


### PR DESCRIPTION
Makes previous hitobject slightly transparent to show that its expired and adds proper fade out animations instead of abruptly deleting the object

![image](https://github.com/user-attachments/assets/6455c53c-8769-435a-b8ac-cb0028a5abdd)
