### PR TITLE
Reconsider mods filtering in `PerformanceCalculator` looking forward to Lazer

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -36,10 +36,6 @@ namespace PerformanceCalculator.Difficulty
                                                                                           + "Values: hr, dt, hd, fl, ez, 4k, 5k, etc...")]
         public string[] Mods { get; }
 
-        [UsedImplicitly]
-        [Option(Template = "-nc|--no-classic", Description = "Excludes the classic mod.")]
-        public bool NoClassicMod { get; }
-
         public override void Execute()
         {
             var resultSet = new ResultSet();
@@ -124,7 +120,7 @@ namespace PerformanceCalculator.Difficulty
         {
             // Get the ruleset
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.Ruleset.OnlineID);
-            var mods = NoClassicMod ? getMods(ruleset) : LegacyHelper.FilterDifficultyAdjustmentMods(beatmap.BeatmapInfo, ruleset, getMods(ruleset));
+            var mods = getMods(ruleset);
             var attributes = ruleset.CreateDifficultyCalculator(beatmap).Calculate(mods);
 
             return new Result

--- a/PerformanceCalculator/Difficulty/LegacyScoreAttributesCommand.cs
+++ b/PerformanceCalculator/Difficulty/LegacyScoreAttributesCommand.cs
@@ -116,8 +116,7 @@ namespace PerformanceCalculator.Difficulty
         private Result processBeatmap(WorkingBeatmap beatmap)
         {
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.Ruleset.OnlineID);
-
-            var mods = LegacyHelper.FilterLegacyMods(beatmap.BeatmapInfo, ruleset, getMods(ruleset));
+            var mods = getMods(ruleset);
 
             var legacyRuleset = (ILegacyRuleset)ruleset;
             var simulator = legacyRuleset.CreateLegacyScoreSimulator();

--- a/PerformanceCalculator/Difficulty/LegacyScoreAttributesCommand.cs
+++ b/PerformanceCalculator/Difficulty/LegacyScoreAttributesCommand.cs
@@ -115,11 +115,9 @@ namespace PerformanceCalculator.Difficulty
 
         private Result processBeatmap(WorkingBeatmap beatmap)
         {
-            // Get the ruleset
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset ?? beatmap.BeatmapInfo.Ruleset.OnlineID);
 
-            // bit of a hack to discard non-legacy mods.
-            var mods = ruleset.ConvertFromLegacyMods(ruleset.ConvertToLegacyMods(getMods(ruleset))).ToList();
+            var mods = LegacyHelper.FilterLegacyMods(beatmap.BeatmapInfo, ruleset, getMods(ruleset));
 
             var legacyRuleset = (ILegacyRuleset)ruleset;
             var simulator = legacyRuleset.CreateLegacyScoreSimulator();

--- a/PerformanceCalculator/Difficulty/LegacyScoreConversionCommand.cs
+++ b/PerformanceCalculator/Difficulty/LegacyScoreConversionCommand.cs
@@ -66,7 +66,7 @@ namespace PerformanceCalculator.Difficulty
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset);
 
             var workingBeatmap = ProcessorWorkingBeatmap.FromFileOrId(Beatmap);
-            Mod[] mods = [ruleset.CreateMod<ModClassic>(), .. LegacyHelper.FilterLegacyMods(workingBeatmap.BeatmapInfo, ruleset, getMods(ruleset))];
+            Mod[] mods = [ruleset.CreateMod<ModClassic>(), .. getMods(ruleset)];
 
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
 

--- a/PerformanceCalculator/Difficulty/LegacyScoreConversionCommand.cs
+++ b/PerformanceCalculator/Difficulty/LegacyScoreConversionCommand.cs
@@ -66,10 +66,8 @@ namespace PerformanceCalculator.Difficulty
             var ruleset = LegacyHelper.GetRulesetFromLegacyID(Ruleset);
 
             var workingBeatmap = ProcessorWorkingBeatmap.FromFileOrId(Beatmap);
-            // bit of a hack to discard non-legacy mods.
-            var mods = ruleset.ConvertFromLegacyMods(ruleset.ConvertToLegacyMods(getMods(ruleset)))
-                              .Append(ruleset.CreateMod<ModClassic>())
-                              .ToArray();
+            Mod[] mods = [ruleset.CreateMod<ModClassic>(), .. LegacyHelper.FilterLegacyMods(workingBeatmap.BeatmapInfo, ruleset, getMods(ruleset))];
+
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
 
             var scoreInfo = new ScoreInfo(beatmap.BeatmapInfo, ruleset.RulesetInfo)

--- a/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
+++ b/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
@@ -62,7 +62,7 @@ namespace PerformanceCalculator.Leaderboard
                     var score = new ProcessorScoreDecoder(working).Parse(scoreInfo);
 
                     var difficultyCalculator = ruleset.CreateDifficultyCalculator(working);
-                    var difficultyAttributes = difficultyCalculator.Calculate(LegacyHelper.FilterDifficultyAdjustmentMods(working.BeatmapInfo, ruleset, scoreInfo.Mods).ToArray());
+                    var difficultyAttributes = difficultyCalculator.Calculate(scoreInfo.Mods);
                     var performanceCalculator = ruleset.CreatePerformanceCalculator();
 
                     plays.Add((performanceCalculator?.Calculate(score.ScoreInfo, difficultyAttributes).Total ?? 0, play.PP ?? 0.0));

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -63,32 +63,6 @@ namespace PerformanceCalculator
             }
         }
 
-        public const LegacyMods KEY_MODS = LegacyMods.Key1 | LegacyMods.Key2 | LegacyMods.Key3 | LegacyMods.Key4 | LegacyMods.Key5 | LegacyMods.Key6 | LegacyMods.Key7 | LegacyMods.Key8
-                                           | LegacyMods.Key9 | LegacyMods.KeyCoop;
-
-        // See: https://github.com/ppy/osu-queue-score-statistics/blob/2264bfa68e14bb16ec71a7cac2072bdcfaf565b6/osu.Server.Queues.ScoreStatisticsProcessor/Helpers/LegacyModsHelper.cs
-        public static LegacyMods MaskRelevantMods(LegacyMods mods, bool isConvertedBeatmap, int rulesetId)
-        {
-            LegacyMods relevantMods = LegacyMods.DoubleTime | LegacyMods.HalfTime | LegacyMods.HardRock | LegacyMods.Easy;
-
-            switch (rulesetId)
-            {
-                case 0:
-                    if ((mods & LegacyMods.Flashlight) > 0)
-                        relevantMods |= LegacyMods.Flashlight | LegacyMods.Hidden | LegacyMods.TouchDevice;
-                    else
-                        relevantMods |= LegacyMods.Flashlight | LegacyMods.TouchDevice;
-                    break;
-
-                case 3:
-                    if (isConvertedBeatmap)
-                        relevantMods |= KEY_MODS;
-                    break;
-            }
-
-            return mods & relevantMods;
-        }
-
         /// <summary>
         /// Transforms a given <see cref="Mod"/> combination into one which is applicable to legacy scores.
         /// This is used to match osu!stable/osu!web calculations for the time being, until such a point that these mods do get considered.
@@ -101,7 +75,7 @@ namespace PerformanceCalculator
             if (mods.Any(mod => mod is ModDaycore))
                 legacyMods |= LegacyMods.HalfTime;
 
-            return MaskRelevantMods(legacyMods, ruleset.RulesetInfo.OnlineID != beatmapInfo.Ruleset.OnlineID, ruleset.RulesetInfo.OnlineID);
+            return legacyMods;
         }
 
         /// <summary>

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -67,7 +67,7 @@ namespace PerformanceCalculator
         /// Transforms a given <see cref="Mod"/> combination into one which is applicable to legacy scores.
         /// This is used to match osu!stable/osu!web calculations for the time being, until such a point that these mods do get considered.
         /// </summary>
-        public static LegacyMods ConvertToLegacyDifficultyAdjustmentMods(BeatmapInfo beatmapInfo, Ruleset ruleset, Mod[] mods)
+        public static LegacyMods ConvertToLegacyMods(BeatmapInfo beatmapInfo, Ruleset ruleset, Mod[] mods)
         {
             var legacyMods = ruleset.ConvertToLegacyMods(mods);
 
@@ -82,8 +82,8 @@ namespace PerformanceCalculator
         /// Transforms a given <see cref="Mod"/> combination into one which is applicable to legacy scores.
         /// This is used to match osu!stable/osu!web calculations for the time being, until such a point that these mods do get considered.
         /// </summary>
-        public static Mod[] FilterDifficultyAdjustmentMods(BeatmapInfo beatmapInfo, Ruleset ruleset, Mod[] mods)
-            => ruleset.ConvertFromLegacyMods(ConvertToLegacyDifficultyAdjustmentMods(beatmapInfo, ruleset, mods)).ToArray();
+        public static Mod[] FilterLegacyMods(BeatmapInfo beatmapInfo, Ruleset ruleset, Mod[] mods)
+            => ruleset.ConvertFromLegacyMods(ConvertToLegacyMods(beatmapInfo, ruleset, mods)).ToArray();
 
         public static DifficultyAttributes CreateDifficultyAttributes(int legacyId)
         {

--- a/PerformanceCalculator/LegacyHelper.cs
+++ b/PerformanceCalculator/LegacyHelper.cs
@@ -2,16 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
-using osu.Game.Beatmaps;
-using osu.Game.Beatmaps.Legacy;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Catch;
 using osu.Game.Rulesets.Catch.Difficulty;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mania.Difficulty;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
 using osu.Game.Rulesets.Osu.Difficulty;
 using osu.Game.Rulesets.Taiko;
@@ -62,28 +58,6 @@ namespace PerformanceCalculator
                     return "mania";
             }
         }
-
-        /// <summary>
-        /// Transforms a given <see cref="Mod"/> combination into one which is applicable to legacy scores.
-        /// This is used to match osu!stable/osu!web calculations for the time being, until such a point that these mods do get considered.
-        /// </summary>
-        public static LegacyMods ConvertToLegacyMods(BeatmapInfo beatmapInfo, Ruleset ruleset, Mod[] mods)
-        {
-            var legacyMods = ruleset.ConvertToLegacyMods(mods);
-
-            // mods that are not represented in `LegacyMods` (but we can approximate them well enough with others)
-            if (mods.Any(mod => mod is ModDaycore))
-                legacyMods |= LegacyMods.HalfTime;
-
-            return legacyMods;
-        }
-
-        /// <summary>
-        /// Transforms a given <see cref="Mod"/> combination into one which is applicable to legacy scores.
-        /// This is used to match osu!stable/osu!web calculations for the time being, until such a point that these mods do get considered.
-        /// </summary>
-        public static Mod[] FilterLegacyMods(BeatmapInfo beatmapInfo, Ruleset ruleset, Mod[] mods)
-            => ruleset.ConvertFromLegacyMods(ConvertToLegacyMods(beatmapInfo, ruleset, mods)).ToArray();
 
         public static DifficultyAttributes CreateDifficultyAttributes(int legacyId)
         {

--- a/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
@@ -9,7 +9,6 @@ using osu.Game.Beatmaps;
 using osu.Game.Database;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring.Legacy;
 using osu.Game.Scoring;
 using osu.Game.Scoring.Legacy;
@@ -38,8 +37,6 @@ namespace PerformanceCalculator.Performance
             var workingBeatmap = ProcessorWorkingBeatmap.FromFileOrId(score.ScoreInfo.BeatmapInfo!.OnlineID.ToString());
             var playableBeatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, score.ScoreInfo.Mods);
 
-            Mod[] difficultyMods = score.ScoreInfo.Mods;
-
             if (score.ScoreInfo.IsLegacyScore)
             {
                 score.ScoreInfo.LegacyTotalScore = (int)score.ScoreInfo.TotalScore;
@@ -51,7 +48,7 @@ namespace PerformanceCalculator.Performance
                     ((ILegacyRuleset)ruleset).CreateLegacyScoreSimulator().Simulate(workingBeatmap, playableBeatmap));
             }
 
-            var difficultyAttributes = ruleset.CreateDifficultyCalculator(workingBeatmap).Calculate(difficultyMods);
+            var difficultyAttributes = ruleset.CreateDifficultyCalculator(workingBeatmap).Calculate(score.ScoreInfo.Mods);
             var performanceCalculator = score.ScoreInfo.Ruleset.CreateInstance().CreatePerformanceCalculator();
             var performanceAttributes = performanceCalculator?.Calculate(score.ScoreInfo, difficultyAttributes);
 

--- a/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
@@ -42,7 +42,6 @@ namespace PerformanceCalculator.Performance
 
             if (score.ScoreInfo.IsLegacyScore)
             {
-                difficultyMods = LegacyHelper.FilterLegacyMods(workingBeatmap.BeatmapInfo, ruleset, difficultyMods);
                 score.ScoreInfo.LegacyTotalScore = (int)score.ScoreInfo.TotalScore;
                 LegacyScoreDecoder.PopulateMaximumStatistics(score.ScoreInfo, workingBeatmap);
                 StandardisedScoreMigrationTools.UpdateFromLegacy(

--- a/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/ReplayPerformanceCommand.cs
@@ -42,7 +42,7 @@ namespace PerformanceCalculator.Performance
 
             if (score.ScoreInfo.IsLegacyScore)
             {
-                difficultyMods = LegacyHelper.FilterDifficultyAdjustmentMods(workingBeatmap.BeatmapInfo, ruleset, difficultyMods);
+                difficultyMods = LegacyHelper.FilterLegacyMods(workingBeatmap.BeatmapInfo, ruleset, difficultyMods);
                 score.ScoreInfo.LegacyTotalScore = (int)score.ScoreInfo.TotalScore;
                 LegacyScoreDecoder.PopulateMaximumStatistics(score.ScoreInfo, workingBeatmap);
                 StandardisedScoreMigrationTools.UpdateFromLegacy(

--- a/PerformanceCalculator/Performance/ScorePerformanceCommand.cs
+++ b/PerformanceCalculator/Performance/ScorePerformanceCommand.cs
@@ -46,13 +46,13 @@ namespace PerformanceCalculator.Performance
 
             if (OnlineAttributes)
             {
-                LegacyMods legacyMods = LegacyHelper.ConvertToLegacyDifficultyAdjustmentMods(workingBeatmap.BeatmapInfo, ruleset, score.Mods);
+                LegacyMods legacyMods = LegacyHelper.ConvertToLegacyMods(workingBeatmap.BeatmapInfo, ruleset, score.Mods);
                 attributes = queryApiAttributes(apiScore.BeatmapID, apiScore.RulesetID, legacyMods);
             }
             else
             {
                 var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);
-                attributes = difficultyCalculator.Calculate(LegacyHelper.FilterDifficultyAdjustmentMods(workingBeatmap.BeatmapInfo, ruleset, score.Mods));
+                attributes = difficultyCalculator.Calculate(score.Mods);
             }
 
             var performanceCalculator = ruleset.CreatePerformanceCalculator();

--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Alba.CsConsoleFormat" Version="1.0.0" />

--- a/PerformanceCalculator/PerformanceCalculator.csproj
+++ b/PerformanceCalculator/PerformanceCalculator.csproj
@@ -7,10 +7,10 @@
   <ItemGroup>
     <PackageReference Include="Alba.CsConsoleFormat" Version="1.0.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
-    <PackageReference Include="ppy.osu.Game" Version="2024.130.2" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.130.2" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.130.2" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.130.2" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.130.2" />
+    <PackageReference Include="ppy.osu.Game" Version="2024.1009.1" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2024.1009.1" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2024.1009.1" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2024.1009.1" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2024.1009.1" />
   </ItemGroup>
 </Project>

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -28,10 +28,6 @@ namespace PerformanceCalculator.Profile
         [AllowedValues("0", "1", "2", "3")]
         public int? Ruleset { get; }
 
-        [UsedImplicitly]
-        [Option(Template = "-or|--only-ranked-mods", Description = "Excludes mods currently considered unranked.")]
-        public bool OnlyRankedMods { get; set; }
-
         public override void Execute()
         {
             var displayPlays = new List<UserPlayInfo>();
@@ -49,11 +45,6 @@ namespace PerformanceCalculator.Profile
                 var working = ProcessorWorkingBeatmap.FromFileOrId(play.BeatmapID.ToString());
 
                 Mod[] mods = play.Mods.Select(x => x.ToMod(ruleset)).ToArray();
-
-                if (OnlyRankedMods)
-                {
-                    mods = LegacyHelper.FilterLegacyMods(working.BeatmapInfo, ruleset, mods);
-                }
 
                 var scoreInfo = play.ToScoreInfo(mods);
                 scoreInfo.Ruleset = ruleset.RulesetInfo;

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -48,16 +48,12 @@ namespace PerformanceCalculator.Simulate
         [UsedImplicitly]
         public virtual int? Goods { get; }
 
-        [UsedImplicitly]
-        [Option(Template = "-nc|--no-classic", Description = "Excludes the classic mod.")]
-        public bool NoClassicMod { get; }
-
         public override void Execute()
         {
             var ruleset = Ruleset;
 
             var workingBeatmap = ProcessorWorkingBeatmap.FromFileOrId(Beatmap);
-            var mods = NoClassicMod ? GetMods(ruleset) : LegacyHelper.FilterDifficultyAdjustmentMods(workingBeatmap.BeatmapInfo, ruleset, GetMods(ruleset));
+            var mods = GetMods(ruleset);
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
 
             var beatmapMaxCombo = GetMaxCombo(beatmap);


### PR DESCRIPTION
Currently, the legacy mods are masked to only include "relevant" mods. By the current code, "relevant" is defined as in having an affect on the star rating. This causes trouble because some mods, whilst not changing the star rating, affect PP. Mods like hidden, who are crucial to include, are simply ignored.

This currently causes trouble with usage in combination with the website https://pp.huismetbenen.nl/ that is a key element in PP development. The maintainer currently runs a "fixed" version locally, although managing it is troublesome. Helix has tried PRing this before in #209 but I decided to pick it up in a separate PR to address it properly.

Instead, I decided to remove it completely since there's no hurt in inputting mods that don't affect PP into the calculator. It'd also mean that if changes happen, eg. HD affecting star rating through the introduction of a proper reading skill, there's no extra effort in having to keep osu-tools up with it.

---
Here's a simple example to see the change (example score is [mrekk's save me](https://osu.ppy.sh/scores/3423842048), which is 1665pp):

### Before
`dotnet run -- simulate osu 1256809 -m HD -m DT -c 4292 -G 85 -M 1` → 1,577pp 
`dotnet run -- simulate osu 1256809 -m DT -c 4292 -G 85 -M 1` → 1,577pp

### After
`dotnet run -- simulate osu 1256809 -m HD -m DT -c 4292 -G 85 -M 1` → 1,644pp 
`dotnet run -- simulate osu 1256809 -m DT -c 4292 -G 85 -M 1` → 1,577pp

You can safely ignore the 1pp difference, that's normal due to the 1665pp being calculated through osu-performance and having tiny decimal differences on some scores.