### PR TITLE
Add default `OverlayColourProvider` to fix popover crash

### DIFF
--- a/PerformanceCalculatorGUI/PerformanceCalculatorSceneManager.cs
+++ b/PerformanceCalculatorGUI/PerformanceCalculatorSceneManager.cs
@@ -42,6 +42,9 @@ namespace PerformanceCalculatorGUI
         [Resolved]
         private DialogOverlay dialogOverlay { get; set; }
 
+        [Cached]
+        private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Blue);
+
         public PerformanceCalculatorSceneManager()
         {
             RelativeSizeAxes = Axes.Both;


### PR DESCRIPTION
This fixes file choosing popover in simualte screen crashing on current `osu` master. Nuget bump isn't required here so it can be merged as is