### PR TITLE
Disable tablet input handler on start

### DIFF
--- a/PerformanceCalculatorGUI/PerformanceCalculatorGame.cs
+++ b/PerformanceCalculatorGUI/PerformanceCalculatorGame.cs
@@ -3,10 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Input.Handlers.Tablet;
 using osu.Framework.Platform;
 using osu.Game;
 using osu.Game.Graphics.Cursor;
@@ -71,6 +73,13 @@ namespace PerformanceCalculatorGUI
             base.SetHost(host);
 
             host.Window.CursorState |= CursorState.Hidden;
+
+            var tabletInputHandler = host.AvailableInputHandlers.FirstOrDefault(x => x is OpenTabletDriverHandler && x.IsActive);
+
+            if (tabletInputHandler != null)
+            {
+                tabletInputHandler.Enabled.Value = false;
+            }
         }
 
         protected override void LoadComplete()

--- a/PerformanceCalculatorGUI/Program.cs
+++ b/PerformanceCalculatorGUI/Program.cs
@@ -15,7 +15,8 @@ namespace PerformanceCalculatorGUI
             using DesktopGameHost host = Host.GetSuitableDesktopHost("PerformanceCalculatorGUI", new HostOptions
             {
                 PortableInstallation = true,
-                BypassCompositor = false
+                BypassCompositor = false,
+                FriendlyGameName = "Performance Calculator GUI"
             });
 
             using var game = new PerformanceCalculatorGame();


### PR DESCRIPTION
Some people are having native driver crashes because of OTD being enabled by default