### PR TITLE
Add option to input large tick misses to simulate screen

### DIFF
--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -103,11 +103,11 @@ namespace PerformanceCalculatorGUI
             return (int)Math.Round(1000000 * scoreMultiplier);
         }
 
-        public static Dictionary<HitResult, int> GenerateHitResultsForRuleset(RulesetInfo ruleset, double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
+        public static Dictionary<HitResult, int> GenerateHitResultsForRuleset(RulesetInfo ruleset, double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int? countLargeTickMisses)
         {
             return ruleset.OnlineID switch
             {
-                0 => generateOsuHitResults(accuracy, beatmap, countMiss, countMeh, countGood),
+                0 => generateOsuHitResults(accuracy, beatmap, countMiss, countMeh, countGood, countLargeTickMisses),
                 1 => generateTaikoHitResults(accuracy, beatmap, countMiss, countGood),
                 2 => generateCatchHitResults(accuracy, beatmap, countMiss, countMeh, countGood),
                 3 => generateManiaHitResults(accuracy, beatmap, countMiss),
@@ -115,7 +115,7 @@ namespace PerformanceCalculatorGUI
             };
         }
 
-        private static Dictionary<HitResult, int> generateOsuHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood)
+        private static Dictionary<HitResult, int> generateOsuHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int? countLargeTickMisses)
         {
             int countGreat;
 
@@ -196,6 +196,7 @@ namespace PerformanceCalculatorGUI
                 { HitResult.Great, countGreat },
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
+                { HitResult.LargeTickMiss, countLargeTickMisses ?? 0 },
                 { HitResult.Miss, countMiss }
             };
         }

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -28,8 +28,6 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
-using osu.Game.Rulesets.Objects.Types;
-using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -28,6 +28,8 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects.Types;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
@@ -52,6 +54,7 @@ namespace PerformanceCalculatorGUI.Screens
         private SwitchButton beatmapImportTypeSwitch;
 
         private LimitedLabelledNumberBox missesTextBox;
+        private LimitedLabelledNumberBox largeTickMissesTextBox;
         private LimitedLabelledNumberBox comboTextBox;
         private LimitedLabelledNumberBox scoreTextBox;
 
@@ -254,14 +257,6 @@ namespace PerformanceCalculatorGUI.Screens
                                                         }
                                                     }
                                                 },
-                                                missesTextBox = new LimitedLabelledNumberBox
-                                                {
-                                                    RelativeSizeAxes = Axes.X,
-                                                    Anchor = Anchor.TopLeft,
-                                                    Label = "Misses",
-                                                    PlaceholderText = "0",
-                                                    MinValue = 0
-                                                },
                                                 comboTextBox = new LimitedLabelledNumberBox
                                                 {
                                                     RelativeSizeAxes = Axes.X,
@@ -269,6 +264,39 @@ namespace PerformanceCalculatorGUI.Screens
                                                     Label = "Combo",
                                                     PlaceholderText = "0",
                                                     MinValue = 0
+                                                },
+                                                new GridContainer
+                                                {
+                                                    RelativeSizeAxes = Axes.X,
+                                                    AutoSizeAxes = Axes.Y,
+                                                    ColumnDimensions = new[]
+                                                    {
+                                                        new Dimension(),
+                                                        new Dimension()
+                                                    },
+                                                    RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                                                    Content = new[]
+                                                    {
+                                                        new Drawable[]
+                                                        {
+                                                            missesTextBox = new LimitedLabelledNumberBox
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                Anchor = Anchor.TopLeft,
+                                                                Label = "Misses",
+                                                                PlaceholderText = "0",
+                                                                MinValue = 0
+                                                            },
+                                                            largeTickMissesTextBox = new LimitedLabelledNumberBox
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                Anchor = Anchor.TopLeft,
+                                                                Label = "Large Tick Misses",
+                                                                PlaceholderText = "0",
+                                                                MinValue = 0
+                                                            }
+                                                        }
+                                                    }
                                                 },
                                                 scoreTextBox = new LimitedLabelledNumberBox
                                                 {
@@ -445,6 +473,7 @@ namespace PerformanceCalculatorGUI.Screens
             goodsTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
             mehsTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
             missesTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
+            largeTickMissesTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
             comboTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
             scoreTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
 
@@ -636,7 +665,8 @@ namespace PerformanceCalculatorGUI.Screens
                 if (ruleset.Value.OnlineID != -1)
                 {
                     // official rulesets can generate more precise hits from accuracy
-                    statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood);
+                    statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood, largeTickMissesTextBox.Value.Value);
+
                     accuracy = RulesetHelper.GetAccuracyForRuleset(ruleset.Value, statistics);
                 }
 
@@ -671,6 +701,7 @@ namespace PerformanceCalculatorGUI.Screens
             accuracyContainer.Hide();
             comboTextBox.Hide();
             missesTextBox.Hide();
+            largeTickMissesTextBox.Hide();
             scoreTextBox.Hide();
 
             if (ruleset.Value.ShortName == "osu" || ruleset.Value.ShortName == "taiko" || ruleset.Value.ShortName == "fruits")
@@ -681,6 +712,11 @@ namespace PerformanceCalculatorGUI.Screens
                 updateCombo(true);
                 comboTextBox.Show();
                 missesTextBox.Show();
+
+                if (ruleset.Value.ShortName == "osu")
+                {
+                    largeTickMissesTextBox.Show();
+                }
             }
             else if (ruleset.Value.ShortName == "mania")
             {
@@ -701,6 +737,7 @@ namespace PerformanceCalculatorGUI.Screens
                 updateCombo(true);
                 comboTextBox.Show();
                 missesTextBox.Show();
+                largeTickMissesTextBox.Show();
 
                 scoreTextBox.Text = string.Empty;
                 scoreTextBox.Show();


### PR DESCRIPTION
Adds a text field for specifying the `HitResult.LargeTickMiss` statistic of the `ScoreInfo` simulated on the simulation screen.
This hit result is currently not considered in PP calculations but will be soon via ppy/osu#27691.

![image](https://github.com/user-attachments/assets/d020c612-4ae9-4dd5-b8ea-db4c7389f53e)
