### PR TITLE
change default beatmap import type of simulation screen to ID

### DIFF
--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -135,8 +135,8 @@ namespace PerformanceCalculatorGUI.Screens
                                 AutoSizeAxes = Axes.Y,
                                 ColumnDimensions = new[]
                                 {
-                                    new Dimension(),
                                     new Dimension(GridSizeMode.Absolute),
+                                    new Dimension(),
                                     new Dimension(GridSizeMode.AutoSize)
                                 },
                                 RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
@@ -423,21 +423,21 @@ namespace PerformanceCalculatorGUI.Screens
                 {
                     beatmapImportContainer.ColumnDimensions = new[]
                     {
+                        new Dimension(),
+                        new Dimension(GridSizeMode.Absolute),
+                        new Dimension(GridSizeMode.AutoSize)
+                    };
+                }
+                else
+                {
+                    beatmapImportContainer.ColumnDimensions = new[]
+                    {
                         new Dimension(GridSizeMode.Absolute),
                         new Dimension(),
                         new Dimension(GridSizeMode.AutoSize)
                     };
 
                     fixupTextBox(beatmapIdTextBox);
-                }
-                else
-                {
-                    beatmapImportContainer.ColumnDimensions = new[]
-                    {
-                        new Dimension(),
-                        new Dimension(GridSizeMode.Absolute),
-                        new Dimension(GridSizeMode.AutoSize)
-                    };
                 }
             });
 


### PR DESCRIPTION
After asking around, as I expected most people rather use the ID import type instead of specifying a local file. Saves a click, especially when restarting alot.