### PR TITLE
Add option to input slider tail hits/misses to simulate screen

### DIFF
--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -15,6 +15,7 @@ using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Mania;
 using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Rulesets.Taiko;
 using osu.Game.Rulesets.Taiko.Objects;
@@ -103,11 +104,11 @@ namespace PerformanceCalculatorGUI
             return (int)Math.Round(1000000 * scoreMultiplier);
         }
 
-        public static Dictionary<HitResult, int> GenerateHitResultsForRuleset(RulesetInfo ruleset, double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int? countLargeTickMisses)
+        public static Dictionary<HitResult, int> GenerateHitResultsForRuleset(RulesetInfo ruleset, bool hasSliderAccuracy, double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int countLargeTickMisses, int countSliderTailMisses)
         {
             return ruleset.OnlineID switch
             {
-                0 => generateOsuHitResults(accuracy, beatmap, countMiss, countMeh, countGood, countLargeTickMisses),
+                0 => generateOsuHitResults(accuracy, hasSliderAccuracy, beatmap, countMiss, countMeh, countGood, countLargeTickMisses, countSliderTailMisses),
                 1 => generateTaikoHitResults(accuracy, beatmap, countMiss, countGood),
                 2 => generateCatchHitResults(accuracy, beatmap, countMiss, countMeh, countGood),
                 3 => generateManiaHitResults(accuracy, beatmap, countMiss),
@@ -115,7 +116,7 @@ namespace PerformanceCalculatorGUI
             };
         }
 
-        private static Dictionary<HitResult, int> generateOsuHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int? countLargeTickMisses)
+        private static Dictionary<HitResult, int> generateOsuHitResults(double accuracy, bool hasSliderAccuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int countLargeTickMisses, int countSliderTailMisses)
         {
             int countGreat;
 
@@ -191,12 +192,15 @@ namespace PerformanceCalculatorGUI
                 countGreat = (int)(totalResultCount - countGood - countMeh - countMiss);
             }
 
+            int sliderTailHits = beatmap.HitObjects.Count(x => x is Slider) - countSliderTailMisses;
+
             return new Dictionary<HitResult, int>
             {
                 { HitResult.Great, countGreat },
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
-                { HitResult.LargeTickMiss, countLargeTickMisses ?? 0 },
+                { HitResult.LargeTickMiss, countLargeTickMisses },
+                { hasSliderAccuracy ? HitResult.SliderTailHit : HitResult.SmallTickHit, sliderTailHits },
                 { HitResult.Miss, countMiss }
             };
         }

--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -104,11 +104,11 @@ namespace PerformanceCalculatorGUI
             return (int)Math.Round(1000000 * scoreMultiplier);
         }
 
-        public static Dictionary<HitResult, int> GenerateHitResultsForRuleset(RulesetInfo ruleset, bool hasSliderAccuracy, double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int countLargeTickMisses, int countSliderTailMisses)
+        public static Dictionary<HitResult, int> GenerateHitResultsForRuleset(RulesetInfo ruleset, double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int countLargeTickMisses, int countSliderTailMisses)
         {
             return ruleset.OnlineID switch
             {
-                0 => generateOsuHitResults(accuracy, hasSliderAccuracy, beatmap, countMiss, countMeh, countGood, countLargeTickMisses, countSliderTailMisses),
+                0 => generateOsuHitResults(accuracy, beatmap, countMiss, countMeh, countGood, countLargeTickMisses, countSliderTailMisses),
                 1 => generateTaikoHitResults(accuracy, beatmap, countMiss, countGood),
                 2 => generateCatchHitResults(accuracy, beatmap, countMiss, countMeh, countGood),
                 3 => generateManiaHitResults(accuracy, beatmap, countMiss),
@@ -116,7 +116,7 @@ namespace PerformanceCalculatorGUI
             };
         }
 
-        private static Dictionary<HitResult, int> generateOsuHitResults(double accuracy, bool hasSliderAccuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int countLargeTickMisses, int countSliderTailMisses)
+        private static Dictionary<HitResult, int> generateOsuHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int countLargeTickMisses, int countSliderTailMisses)
         {
             int countGreat;
 
@@ -200,7 +200,7 @@ namespace PerformanceCalculatorGUI
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
                 { HitResult.LargeTickMiss, countLargeTickMisses },
-                { hasSliderAccuracy ? HitResult.SliderTailHit : HitResult.SmallTickHit, sliderTailHits },
+                { HitResult.SliderTailHit, sliderTailHits },
                 { HitResult.Miss, countMiss }
             };
         }

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -528,7 +528,6 @@ namespace PerformanceCalculatorGUI.Screens
             {
                 if (ruleset.Value.ShortName == "osu")
                 {
-
                     // Large tick misses and slider tail misses are only relevant in PP if slider head accuracy exists
                     if (mods.NewValue.OfType<OsuModClassic>().Any(m => m.NoSliderHeadAccuracy.Value))
                     {

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -28,6 +28,7 @@ using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Difficulty.Skills;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 using osu.Game.Screens.Play.HUD;
@@ -53,6 +54,7 @@ namespace PerformanceCalculatorGUI.Screens
 
         private LimitedLabelledNumberBox missesTextBox;
         private LimitedLabelledNumberBox largeTickMissesTextBox;
+        private LimitedLabelledNumberBox sliderTailMissesTextBox;
         private LimitedLabelledNumberBox comboTextBox;
         private LimitedLabelledNumberBox scoreTextBox;
 
@@ -270,6 +272,7 @@ namespace PerformanceCalculatorGUI.Screens
                                                     ColumnDimensions = new[]
                                                     {
                                                         new Dimension(),
+                                                        new Dimension(),
                                                         new Dimension()
                                                     },
                                                     RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
@@ -290,6 +293,14 @@ namespace PerformanceCalculatorGUI.Screens
                                                                 RelativeSizeAxes = Axes.X,
                                                                 Anchor = Anchor.TopLeft,
                                                                 Label = "Large Tick Misses",
+                                                                PlaceholderText = "0",
+                                                                MinValue = 0
+                                                            },
+                                                            sliderTailMissesTextBox = new LimitedLabelledNumberBox
+                                                            {
+                                                                RelativeSizeAxes = Axes.X,
+                                                                Anchor = Anchor.TopLeft,
+                                                                Label = "Slider Tail Misses",
                                                                 PlaceholderText = "0",
                                                                 MinValue = 0
                                                             }
@@ -472,6 +483,7 @@ namespace PerformanceCalculatorGUI.Screens
             mehsTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
             missesTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
             largeTickMissesTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
+            sliderTailMissesTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
             comboTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
             scoreTextBox.Value.BindValueChanged(_ => debouncedCalculatePerformance());
 
@@ -660,10 +672,13 @@ namespace PerformanceCalculatorGUI.Screens
                 var accuracy = accuracyTextBox.Value.Value / 100.0;
                 Dictionary<HitResult, int> statistics = new Dictionary<HitResult, int>();
 
+                
+
                 if (ruleset.Value.OnlineID != -1)
                 {
                     // official rulesets can generate more precise hits from accuracy
-                    statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood, largeTickMissesTextBox.Value.Value);
+                    bool hasSliderAccuracy = !appliedMods.Value.Any(x => x is OsuModClassic cl && cl.NoSliderHeadAccuracy.Value);
+                    statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, hasSliderAccuracy, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood, largeTickMissesTextBox.Value.Value, sliderTailMissesTextBox.Value.Value);
 
                     accuracy = RulesetHelper.GetAccuracyForRuleset(ruleset.Value, statistics);
                 }
@@ -700,6 +715,7 @@ namespace PerformanceCalculatorGUI.Screens
             comboTextBox.Hide();
             missesTextBox.Hide();
             largeTickMissesTextBox.Hide();
+            sliderTailMissesTextBox.Hide();
             scoreTextBox.Hide();
 
             if (ruleset.Value.ShortName == "osu" || ruleset.Value.ShortName == "taiko" || ruleset.Value.ShortName == "fruits")
@@ -714,6 +730,7 @@ namespace PerformanceCalculatorGUI.Screens
                 if (ruleset.Value.ShortName == "osu")
                 {
                     largeTickMissesTextBox.Show();
+                    sliderTailMissesTextBox.Show();
                 }
             }
             else if (ruleset.Value.ShortName == "mania")
@@ -736,6 +753,7 @@ namespace PerformanceCalculatorGUI.Screens
                 comboTextBox.Show();
                 missesTextBox.Show();
                 largeTickMissesTextBox.Show();
+                sliderTailMissesTextBox.Show();
 
                 scoreTextBox.Text = string.Empty;
                 scoreTextBox.Show();

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -672,8 +672,6 @@ namespace PerformanceCalculatorGUI.Screens
                 var accuracy = accuracyTextBox.Value.Value / 100.0;
                 Dictionary<HitResult, int> statistics = new Dictionary<HitResult, int>();
 
-                
-
                 if (ruleset.Value.OnlineID != -1)
                 {
                     // official rulesets can generate more precise hits from accuracy

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -675,8 +675,7 @@ namespace PerformanceCalculatorGUI.Screens
                 if (ruleset.Value.OnlineID != -1)
                 {
                     // official rulesets can generate more precise hits from accuracy
-                    bool hasSliderAccuracy = !appliedMods.Value.OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
-                    statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, hasSliderAccuracy, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood, largeTickMissesTextBox.Value.Value, sliderTailMissesTextBox.Value.Value);
+                    statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood, largeTickMissesTextBox.Value.Value, sliderTailMissesTextBox.Value.Value);
 
                     accuracy = RulesetHelper.GetAccuracyForRuleset(ruleset.Value, statistics);
                 }

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -677,7 +677,7 @@ namespace PerformanceCalculatorGUI.Screens
                 if (ruleset.Value.OnlineID != -1)
                 {
                     // official rulesets can generate more precise hits from accuracy
-                    bool hasSliderAccuracy = !appliedMods.Value.Any(x => x is OsuModClassic cl && cl.NoSliderHeadAccuracy.Value);
+                    bool hasSliderAccuracy = !appliedMods.Value.OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
                     statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, hasSliderAccuracy, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood, largeTickMissesTextBox.Value.Value, sliderTailMissesTextBox.Value.Value);
 
                     accuracy = RulesetHelper.GetAccuracyForRuleset(ruleset.Value, statistics);


### PR DESCRIPTION
I decided to go with users specifying slider tail *misses* as opposed to *hits* (which is what the hit result represents), since in PP development the actually interesting value are the misses, so it's easier to have that number you work with in PP code to be represented in the UI input.

![image](https://github.com/user-attachments/assets/663f0e53-df04-4e5f-9d9a-c643e2ffd6d2)

If slider head accuracy is disabled, it uses the `HitResult.SmallTickHit` judgement instead, as I got told it does this, haven't personally confirmed it but whoever reviews this will know.