### PR TITLE
fix duplicate difficulty & performance calculation when changing mods

### DIFF
--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -513,7 +513,7 @@ namespace PerformanceCalculatorGUI.Screens
         {
             // Hotfix for preventing a difficulty and performance calculation from being trigger twice,
             // as the mod overlay for some reason triggers a ValueChanged twice per mod change.
-            if (mods.OldValue.Count == mods.NewValue.Count)
+            if (mods.OldValue.SequenceEqual(mods.NewValue))
                 return;
 
             modSettingChangeTracker?.Dispose();

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -529,24 +529,6 @@ namespace PerformanceCalculatorGUI.Screens
             if (mods.OldValue.SequenceEqual(mods.NewValue))
                 return;
 
-            void updateMissesTextboxes()
-            {
-                if (ruleset.Value.ShortName == "osu")
-                {
-                    // Large tick misses and slider tail misses are only relevant in PP if slider head accuracy exists
-                    if (mods.NewValue.OfType<OsuModClassic>().Any(m => m.NoSliderHeadAccuracy.Value))
-                    {
-                        missesContainer.Content = new[] { new[] { missesTextBox } };
-                        missesContainer.ColumnDimensions = [new Dimension()];
-                    }
-                    else
-                    {
-                        missesContainer.Content = new[] { new[] { missesTextBox, largeTickMissesTextBox, sliderTailMissesTextBox } };
-                        missesContainer.ColumnDimensions = [new Dimension(), new Dimension(), new Dimension()];
-                    }
-                }
-            }
-
             modSettingChangeTracker?.Dispose();
 
             if (working is null)
@@ -569,6 +551,24 @@ namespace PerformanceCalculatorGUI.Screens
             calculateDifficulty();
             updateCombo(false);
             calculatePerformance();
+
+            void updateMissesTextboxes()
+            {
+                if (ruleset.Value.ShortName == "osu")
+                {
+                    // Large tick misses and slider tail misses are only relevant in PP if slider head accuracy exists
+                    if (mods.NewValue.OfType<OsuModClassic>().Any(m => m.NoSliderHeadAccuracy.Value))
+                    {
+                        missesContainer.Content = new[] { new[] { missesTextBox } };
+                        missesContainer.ColumnDimensions = [new Dimension()];
+                    }
+                    else
+                    {
+                        missesContainer.Content = new[] { new[] { missesTextBox, largeTickMissesTextBox, sliderTailMissesTextBox } };
+                        missesContainer.ColumnDimensions = [new Dimension(), new Dimension(), new Dimension()];
+                    }
+                }
+            }
         }
 
         private void resetBeatmap()

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -511,6 +511,11 @@ namespace PerformanceCalculatorGUI.Screens
 
         private void modsChanged(ValueChangedEvent<IReadOnlyList<Mod>> mods)
         {
+            // Hotfix for preventing a difficulty and performance calculation from being trigger twice,
+            // as the mod overlay for some reason triggers a ValueChanged twice per mod change.
+            if (mods.OldValue.Count == mods.NewValue.Count)
+                return;
+
             modSettingChangeTracker?.Dispose();
 
             if (working is null)


### PR DESCRIPTION
When changing the mods on the simulation screen in perfcalc GUI, it for some reason triggers the value change event on the bindable twice. As far as I can tell, this behaviour is caused by the control itself in osu.Game, and not by osu-tools.

As I'm not sure about the circumstances under which this behaviour might be desired inside Lazer, I decided to hotfix it by checking the difference between the old and new value, which is the exact same on the second time the bindable's value changed is called.

Furthermore, there is another issue with performance calculation being triggered twice when entering a beatmap ID and calculating it for the first time, since the `updateCombo` method changes the value of the combo textbox, which's bindable is linked to triggering performance calculation. But I think this isn't too critical, as here only performance is recalculated and that's a very quick process, unlike the fix this PR does as this causes difficulty calculation to occur an unecessary extra time, and depending on the map that can take abit of time.

https://github.com/ppy/osu-tools/blob/e387265b073c45d2ebf7f46ba3da7eec853c82f7/PerformanceCalculatorGUI/Screens/SimulateScreen.cs#L870