### PR TITLE
Move `SimulateCommand` option implementations to base class

### DIFF
--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -18,35 +18,21 @@ namespace PerformanceCalculator.Simulate
     public class CatchSimulateCommand : SimulateCommand
     {
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
-                                                                     + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
-        public override double Accuracy { get; } = 100;
-
-        [UsedImplicitly]
         [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]
         public override int? Combo { get; }
 
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
-                                                                       + " Enter as decimal 0-100.")]
-        public override double PercentCombo { get; } = 100;
-
-        [UsedImplicitly]
-        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                            + " Values: hr, dt, hd, fl, ez, etc...")]
-        public override string[] Mods { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
-        public override int Misses { get; }
+                                                                     + " Enter as decimal 0-100.")]
+        public override double PercentCombo { get; }
 
         [UsedImplicitly]
         [Option(Template = "-T|--tiny-droplets <tinys>", Description = "Number of tiny droplets hit. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Mehs { get; }
+        public override int? Mehs { get; set; }
 
         [UsedImplicitly]
         [Option(Template = "-D|--droplets <droplets>", Description = "Number of droplets hit. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Goods { get; }
+        public override int? Goods { get; set; }
 
         public override Ruleset Ruleset => new CatchRuleset();
 

--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -27,11 +27,11 @@ namespace PerformanceCalculator.Simulate
 
         [UsedImplicitly]
         [Option(Template = "-T|--tiny-droplets <tinys>", Description = "Number of tiny droplets hit. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Mehs { get; set; }
+        public override int? Mehs { get; }
 
         [UsedImplicitly]
         [Option(Template = "-D|--droplets <droplets>", Description = "Number of droplets hit. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Goods { get; set; }
+        public override int? Goods { get; }
 
         public override Ruleset Ruleset => new CatchRuleset();
 

--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -24,7 +24,7 @@ namespace PerformanceCalculator.Simulate
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
                                                                      + " Enter as decimal 0-100.")]
-        public override double PercentCombo { get; }
+        public override double PercentCombo { get; } = 100;
 
         [UsedImplicitly]
         [Option(Template = "-T|--tiny-droplets <tinys>", Description = "Number of tiny droplets hit. Will override accuracy if used. Otherwise is automatically calculated.")]

--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -22,8 +22,7 @@ namespace PerformanceCalculator.Simulate
         public override int? Combo { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
-                                                                     + " Enter as decimal 0-100.")]
+        [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.")]
         public override double PercentCombo { get; } = 100;
 
         [UsedImplicitly]

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -18,34 +18,20 @@ namespace PerformanceCalculator.Simulate
     public class ManiaSimulateCommand : SimulateCommand
     {
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
-                                                                     + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
-        public override double Accuracy { get; } = 100;
-
-        [UsedImplicitly]
-        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
-        public override int Misses { get; }
-
-        [UsedImplicitly]
         [Option(Template = "-M|--mehs <mehs>", Description = "Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Mehs { get; }
+        public override int? Mehs { get; set; }
+
+        [UsedImplicitly]
+        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Goods { get; set; }
 
         [UsedImplicitly]
         [Option(Template = "-O|--oks <oks>", Description = "Number of oks. Will override accuracy if used. Otherwise is automatically calculated.")]
         private int? oks { get; set; }
 
         [UsedImplicitly]
-        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Goods { get; }
-
-        [UsedImplicitly]
         [Option(Template = "-T|--greats <greats>", Description = "Number of greats. Will override accuracy if used. Otherwise is automatically calculated.")]
         private int? greats { get; set; }
-
-        [UsedImplicitly]
-        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                            + " Values: hr, dt, fl, 4k, 5k, etc...")]
-        public override string[] Mods { get; }
 
         public override Ruleset Ruleset => new ManiaRuleset();
 

--- a/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/ManiaSimulateCommand.cs
@@ -19,19 +19,19 @@ namespace PerformanceCalculator.Simulate
     {
         [UsedImplicitly]
         [Option(Template = "-M|--mehs <mehs>", Description = "Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Mehs { get; set; }
+        public override int? Mehs { get; }
 
         [UsedImplicitly]
         [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Goods { get; set; }
+        public override int? Goods { get; }
 
         [UsedImplicitly]
         [Option(Template = "-O|--oks <oks>", Description = "Number of oks. Will override accuracy if used. Otherwise is automatically calculated.")]
-        private int? oks { get; set; }
+        private int? oks { get; }
 
         [UsedImplicitly]
         [Option(Template = "-T|--greats <greats>", Description = "Number of greats. Will override accuracy if used. Otherwise is automatically calculated.")]
-        private int? greats { get; set; }
+        private int? greats { get; }
 
         public override Ruleset Ruleset => new ManiaRuleset();
 
@@ -68,10 +68,10 @@ namespace PerformanceCalculator.Simulate
             // Each great and perfect increases total by 5 (great-meh=5)
             // There is no difference in accuracy between them, so just halve arbitrarily (favouring perfects for an odd number).
             int greatsAndPerfects = Math.Min(delta / 5, remainingHits);
-            greats = greatsAndPerfects / 2;
-            int perfects = greatsAndPerfects - greats.Value;
-            delta -= (greats.Value + perfects) * 5;
-            remainingHits -= greats.Value + perfects;
+            int countGreat = greatsAndPerfects / 2;
+            int perfects = greatsAndPerfects - countGreat;
+            delta -= (countGreat + perfects) * 5;
+            remainingHits -= countGreat + perfects;
 
             // Each good increases total by 3 (good-meh=3).
             countGood = Math.Min(delta / 3, remainingHits);
@@ -79,8 +79,8 @@ namespace PerformanceCalculator.Simulate
             remainingHits -= countGood.Value;
 
             // Each ok increases total by 1 (ok-meh=1).
-            oks = delta;
-            remainingHits -= oks.Value;
+            int countOk = delta;
+            remainingHits -= countOk;
 
             // Everything else is a meh, as initially assumed.
             countMeh = remainingHits;
@@ -88,8 +88,8 @@ namespace PerformanceCalculator.Simulate
             return new Dictionary<HitResult, int>
             {
                 { HitResult.Perfect, perfects },
-                { HitResult.Great, greats.Value },
-                { HitResult.Ok, oks.Value },
+                { HitResult.Great, countGreat },
+                { HitResult.Ok, countOk },
                 { HitResult.Good, countGood.Value },
                 { HitResult.Meh, countMeh.Value },
                 { HitResult.Miss, countMiss }

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -30,7 +30,7 @@ namespace PerformanceCalculator.Simulate
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
                                                                      + " Enter as decimal 0-100.")]
-        public override double PercentCombo { get; }
+        public override double PercentCombo { get; } = 100;
 
         public override Ruleset Ruleset => new OsuRuleset();
 

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -16,9 +16,12 @@ namespace PerformanceCalculator.Simulate
     public class OsuSimulateCommand : SimulateCommand
     {
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
-                                                                     + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
-        public override double Accuracy { get; } = 100;
+        [Option(Template = "-M|--mehs <mehs>", Description = "Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Mehs { get; set; }
+
+        [UsedImplicitly]
+        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Goods { get; set; }
 
         [UsedImplicitly]
         [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]
@@ -26,25 +29,8 @@ namespace PerformanceCalculator.Simulate
 
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
-                                                                       + " Enter as decimal 0-100.")]
-        public override double PercentCombo { get; } = 100;
-
-        [UsedImplicitly]
-        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                            + " Values: hr, dt, hd, fl, ez, etc...")]
-        public override string[] Mods { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
-        public override int Misses { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-M|--mehs <mehs>", Description = "Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Mehs { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Goods { get; }
+                                                                     + " Enter as decimal 0-100.")]
+        public override double PercentCombo { get; }
 
         public override Ruleset Ruleset => new OsuRuleset();
 

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -17,11 +17,11 @@ namespace PerformanceCalculator.Simulate
     {
         [UsedImplicitly]
         [Option(Template = "-M|--mehs <mehs>", Description = "Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Mehs { get; set; }
+        public override int? Mehs { get; }
 
         [UsedImplicitly]
         [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Goods { get; set; }
+        public override int? Goods { get; }
 
         [UsedImplicitly]
         [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -28,8 +28,7 @@ namespace PerformanceCalculator.Simulate
         public override int? Combo { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
-                                                                     + " Enter as decimal 0-100.")]
+        [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.")]
         public override double PercentCombo { get; } = 100;
 
         public override Ruleset Ruleset => new OsuRuleset();

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -25,13 +25,11 @@ namespace PerformanceCalculator.Simulate
         public string Beatmap { get; set; }
 
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
-                                                                   + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
         public double Accuracy { get; set; } = 100;
 
         [UsedImplicitly]
-        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                          + " Values: hr, dt, hd, fl, etc...")]
+        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, etc...")]
         public string[] Mods { get; set; }
 
         [UsedImplicitly]

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -22,19 +22,19 @@ namespace PerformanceCalculator.Simulate
         [UsedImplicitly]
         [Required]
         [Argument(0, Name = "beatmap", Description = "Required. Can be either a path to beatmap file (.osu) or beatmap ID.")]
-        public string Beatmap { get; set; }
+        public string Beatmap { get; }
 
         [UsedImplicitly]
         [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
-        public double Accuracy { get; set; } = 100;
+        public double Accuracy { get; } = 100;
 
         [UsedImplicitly]
         [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, etc...")]
-        public string[] Mods { get; set; }
+        public string[] Mods { get; }
 
         [UsedImplicitly]
         [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
-        public int Misses { get; set; }
+        public int Misses { get; }
 
         //
         // Options implemented in the ruleset-specific commands
@@ -43,10 +43,10 @@ namespace PerformanceCalculator.Simulate
         // -> Taiko does not have Mehs
         //
         [UsedImplicitly]
-        public virtual int? Mehs { get; set; }
+        public virtual int? Mehs { get; }
 
         [UsedImplicitly]
-        public virtual int? Goods { get; set; }
+        public virtual int? Goods { get; }
 
         [UsedImplicitly]
         public virtual int? Combo { get; }

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -22,31 +22,39 @@ namespace PerformanceCalculator.Simulate
         [UsedImplicitly]
         [Required]
         [Argument(0, Name = "beatmap", Description = "Required. Can be either a path to beatmap file (.osu) or beatmap ID.")]
-        public string Beatmap { get; }
+        public string Beatmap { get; set; }
 
         [UsedImplicitly]
-        public virtual double Accuracy { get; }
+        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
+                                                                   + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
+        public double Accuracy { get; set; } = 100;
+
+        [UsedImplicitly]
+        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
+                                                                                          + " Values: hr, dt, hd, fl, etc...")]
+        public string[] Mods { get; set; }
+
+        [UsedImplicitly]
+        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
+        public int Misses { get; set; }
+
+        //
+        // Options implemented in the ruleset-specific commands
+        // -> Catch renames Mehs/Goods to (tiny-)droplets
+        // -> Mania does not have Combo
+        // -> Taiko does not have Mehs
+        //
+        [UsedImplicitly]
+        public virtual int? Mehs { get; set; }
+
+        [UsedImplicitly]
+        public virtual int? Goods { get; set; }
 
         [UsedImplicitly]
         public virtual int? Combo { get; }
 
         [UsedImplicitly]
         public virtual double PercentCombo { get; }
-
-        [UsedImplicitly]
-        public virtual int Score { get; }
-
-        [UsedImplicitly]
-        public virtual string[] Mods { get; }
-
-        [UsedImplicitly]
-        public virtual int Misses { get; }
-
-        [UsedImplicitly]
-        public virtual int? Mehs { get; }
-
-        [UsedImplicitly]
-        public virtual int? Goods { get; }
 
         public override void Execute()
         {
@@ -63,8 +71,7 @@ namespace PerformanceCalculator.Simulate
                 Accuracy = GetAccuracy(statistics),
                 MaxCombo = Combo ?? (int)Math.Round(PercentCombo / 100 * beatmapMaxCombo),
                 Statistics = statistics,
-                Mods = mods,
-                TotalScore = Score,
+                Mods = mods
             };
 
             var difficultyCalculator = ruleset.CreateDifficultyCalculator(workingBeatmap);

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -28,7 +28,7 @@ namespace PerformanceCalculator.Simulate
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
                                                                      + " Enter as decimal 0-100.")]
-        public override double PercentCombo { get; }
+        public override double PercentCombo { get; } = 100;
 
         public override Ruleset Ruleset => new TaikoRuleset();
 

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -19,7 +19,7 @@ namespace PerformanceCalculator.Simulate
     {
         [UsedImplicitly]
         [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Goods { get; set; }
+        public override int? Goods { get; }
 
         [UsedImplicitly]
         [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -26,8 +26,7 @@ namespace PerformanceCalculator.Simulate
         public override int? Combo { get; }
 
         [UsedImplicitly]
-        [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
-                                                                     + " Enter as decimal 0-100.")]
+        [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.")]
         public override double PercentCombo { get; } = 100;
 
         public override Ruleset Ruleset => new TaikoRuleset();

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -18,9 +18,8 @@ namespace PerformanceCalculator.Simulate
     public class TaikoSimulateCommand : SimulateCommand
     {
         [UsedImplicitly]
-        [Option(Template = "-a|--accuracy <accuracy>", Description = "Accuracy. Enter as decimal 0-100. Defaults to 100."
-                                                                     + " Scales hit results as well and is rounded to the nearest possible value for the beatmap.")]
-        public override double Accuracy { get; } = 100;
+        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
+        public override int? Goods { get; set; }
 
         [UsedImplicitly]
         [Option(Template = "-c|--combo <combo>", Description = "Maximum combo during play. Defaults to beatmap maximum.")]
@@ -28,21 +27,8 @@ namespace PerformanceCalculator.Simulate
 
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option."
-                                                                       + " Enter as decimal 0-100.")]
-        public override double PercentCombo { get; } = 100;
-
-        [UsedImplicitly]
-        [Option(CommandOptionType.MultipleValue, Template = "-m|--mod <mod>", Description = "One for each mod. The mods to compute the performance with."
-                                                                                            + " Values: hr, dt, hd, fl, ez, etc...")]
-        public override string[] Mods { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
-        public override int Misses { get; }
-
-        [UsedImplicitly]
-        [Option(Template = "-G|--goods <goods>", Description = "Number of goods. Will override accuracy if used. Otherwise is automatically calculated.")]
-        public override int? Goods { get; }
+                                                                     + " Enter as decimal 0-100.")]
+        public override double PercentCombo { get; }
 
         public override Ruleset Ruleset => new TaikoRuleset();
 


### PR DESCRIPTION
Moves the option attributes of all parameters of the simulate command where every ruleset has the same implementations to the base class. The reduces the amount of boilerplate code in each simulate command class.

The only parameters excluded are:
- Mehs/Goods, since Catch renames them to droplets and Taiko does not have Mehs
- Combo/ComboPercent, as Mania does not have combo