### PR TITLE
Add `--mod-option` parameter to simulate command

### DIFF
--- a/PerformanceCalculator/Difficulty/DifficultyCommand.cs
+++ b/PerformanceCalculator/Difficulty/DifficultyCommand.cs
@@ -63,9 +63,6 @@ namespace PerformanceCalculator.Difficulty
                 string json = JsonConvert.SerializeObject(resultSet);
 
                 Console.WriteLine(json);
-
-                if (OutputFile != null)
-                    File.WriteAllText(OutputFile, json);
             }
             else
             {

--- a/PerformanceCalculator/Difficulty/LegacyScoreAttributesCommand.cs
+++ b/PerformanceCalculator/Difficulty/LegacyScoreAttributesCommand.cs
@@ -62,9 +62,6 @@ namespace PerformanceCalculator.Difficulty
                 string json = JsonConvert.SerializeObject(resultSet);
 
                 Console.WriteLine(json);
-
-                if (OutputFile != null)
-                    File.WriteAllText(OutputFile, json);
             }
             else
             {

--- a/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
+++ b/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Alba.CsConsoleFormat;
 using JetBrains.Annotations;

--- a/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
+++ b/PerformanceCalculator/Leaderboard/LeaderboardCommand.cs
@@ -98,9 +98,6 @@ namespace PerformanceCalculator.Leaderboard
                 var json = JsonConvert.SerializeObject(calculatedPlayers);
 
                 Console.Write(json);
-
-                if (OutputFile != null)
-                    File.WriteAllText(OutputFile, json);
             }
             else
             {

--- a/PerformanceCalculator/ProcessorCommand.cs
+++ b/PerformanceCalculator/ProcessorCommand.cs
@@ -12,7 +12,9 @@ using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using Newtonsoft.Json;
 using osu.Game.Online.API;
+using osu.Game.Rulesets;
 using osu.Game.Rulesets.Difficulty;
+using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
@@ -129,6 +131,35 @@ namespace PerformanceCalculator
 
         public virtual void Execute()
         {
+        }
+
+        public static Mod[] ParseMods(Ruleset ruleset, string[] acronyms, string[] options)
+        {
+            acronyms ??= [];
+            options ??= [];
+
+            if (acronyms.Length == 0)
+                return [];
+
+            var mods = new List<Mod>();
+
+            foreach (var acronym in acronyms)
+            {
+                APIMod mod = new APIMod { Acronym = acronym };
+
+                foreach (string modOption in options.Where(x => x.StartsWith($"{acronym}_", StringComparison.CurrentCultureIgnoreCase)))
+                {
+                    string[] split = modOption[3..].Split('=');
+                    if (split.Length != 2)
+                        throw new ArgumentException($"Invalid mod-option format (key=value): {modOption[3..]}");
+
+                    mod.Settings[split[0]] = split[1];
+                }
+
+                mods.Add(mod.ToMod(ruleset));
+            }
+
+            return mods.ToArray();
         }
 
         private class Result

--- a/PerformanceCalculator/ProcessorCommand.cs
+++ b/PerformanceCalculator/ProcessorCommand.cs
@@ -147,11 +147,13 @@ namespace PerformanceCalculator
             {
                 APIMod mod = new APIMod { Acronym = acronym };
 
-                foreach (string modOption in options.Where(x => x.StartsWith($"{acronym}_", StringComparison.CurrentCultureIgnoreCase)))
+                foreach (string optionString in options.Where(x => x.StartsWith($"{acronym}_", StringComparison.CurrentCultureIgnoreCase)))
                 {
-                    string[] split = modOption[3..].Split('=');
+                    string optionTuple = optionString[(acronym.Length + 1)..];
+
+                    string[] split = optionTuple.Split('=');
                     if (split.Length != 2)
-                        throw new ArgumentException($"Invalid mod-option format (key=value): {modOption[3..]}");
+                        throw new ArgumentException($"Invalid mod-option format (key=value): {optionTuple}");
 
                     mod.Settings[split[0]] = split[1];
                 }

--- a/PerformanceCalculator/ProcessorCommand.cs
+++ b/PerformanceCalculator/ProcessorCommand.cs
@@ -27,10 +27,6 @@ namespace PerformanceCalculator
         public IConsole Console { get; private set; }
 
         [UsedImplicitly]
-        [Option(Template = "-o|--output <file.txt>", Description = "Output results to text file.")]
-        public string OutputFile { get; }
-
-        [UsedImplicitly]
         [Option(Template = "-j|--json", Description = "Output results as JSON.")]
         public bool OutputJson { get; }
 
@@ -65,9 +61,6 @@ namespace PerformanceCalculator
                 string json = JsonConvert.SerializeObject(result, Formatting.Indented);
 
                 Console.WriteLine(json);
-
-                if (OutputFile != null)
-                    File.WriteAllText(OutputFile, json);
             }
             else
             {
@@ -131,8 +124,6 @@ namespace PerformanceCalculator
                 str = string.Join('\n', lines);
 
                 Console.Write(str);
-                if (OutputFile != null)
-                    File.WriteAllText(OutputFile, str);
             }
         }
 

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using Alba.CsConsoleFormat;
 using JetBrains.Annotations;

--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -109,9 +109,6 @@ namespace PerformanceCalculator.Profile
                 });
 
                 Console.Write(json);
-
-                if (OutputFile != null)
-                    File.WriteAllText(OutputFile, json);
             }
             else
             {

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -4,13 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Linq;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
-using osu.Game.Online.API;
 using osu.Game.Rulesets;
-using osu.Game.Rulesets.Mods;
 using osu.Game.Rulesets.Scoring;
 using osu.Game.Scoring;
 
@@ -65,7 +62,7 @@ namespace PerformanceCalculator.Simulate
             var ruleset = Ruleset;
 
             var workingBeatmap = ProcessorWorkingBeatmap.FromFileOrId(Beatmap);
-            var mods = GetMods(ruleset);
+            var mods = ParseMods(ruleset, Mods, ModOptions);
             var beatmap = workingBeatmap.GetPlayableBeatmap(ruleset.RulesetInfo, mods);
 
             var beatmapMaxCombo = GetMaxCombo(beatmap);
@@ -84,32 +81,6 @@ namespace PerformanceCalculator.Simulate
             var performanceAttributes = performanceCalculator?.Calculate(scoreInfo, difficultyAttributes);
 
             OutputPerformance(scoreInfo, performanceAttributes, difficultyAttributes);
-        }
-
-        protected Mod[] GetMods(Ruleset ruleset)
-        {
-            if (Mods == null)
-                return Array.Empty<Mod>();
-
-            var mods = new List<Mod>();
-
-            foreach (var modString in Mods)
-            {
-                APIMod mod = new APIMod { Acronym = modString };
-
-                foreach (string modOption in ModOptions.Where(x => x.StartsWith($"{modString}_", StringComparison.CurrentCultureIgnoreCase)))
-                {
-                    string[] split = modOption[3..].Split('=');
-                    if (split.Length != 2)
-                        throw new ArgumentException($"Invalid mod-option format (key=value): {modOption[3..]}");
-
-                    mod.Settings[split[0]] = split[1];
-                }
-
-                mods.Add(mod.ToMod(ruleset));
-            }
-
-            return mods.ToArray();
         }
 
         protected abstract int GetMaxCombo(IBeatmap beatmap);

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -4,16 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Globalization;
 using System.Linq;
-using System.Reflection;
-using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
-using osu.Framework.Bindables;
 using osu.Game.Beatmaps;
-using osu.Game.Configuration;
-using osu.Game.Extensions;
 using osu.Game.Online.API;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Mods;
@@ -97,14 +91,13 @@ namespace PerformanceCalculator.Simulate
             if (Mods == null)
                 return Array.Empty<Mod>();
 
-            var availableMods = ruleset.CreateAllMods().ToList();
             var mods = new List<Mod>();
 
             foreach (var modString in Mods)
             {
-                APIMod mod = new APIMod() { Acronym = modString };
+                APIMod mod = new APIMod { Acronym = modString };
 
-                foreach(string modOption in ModOptions.Where(x => x.ToUpper().StartsWith($"{modString}_")))
+                foreach (string modOption in ModOptions.Where(x => x.StartsWith($"{modString}_", StringComparison.CurrentCultureIgnoreCase)))
                 {
                     string[] split = modOption[3..].Split('=');
                     if (split.Length != 2)


### PR DESCRIPTION
Depends on #223 

This adds a mod option parameter for specifying mod settings. The syntax is `-o|--mod-option <acronym>_<setting>=<value>`.
Example: `dotnet run -- simulate osu 4697929 -m DT -m DA -o DT_speed_change=1.3 -o DA_overall_difficulty=1`

Additionally, this PR removes the `--output` parameter as it was deemed unecessary (any shell allows you do write to a file via `|` or `>`) and used the `-o` parameter already.