### PR TITLE
Add `--large-tick-misses` and `--slider-tail-misses` parameters to simulate command

### DIFF
--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -122,16 +122,13 @@ namespace PerformanceCalculator.Simulate
                 countGreat = (int)(totalResultCount - countGood - countMeh - countMiss);
             }
 
-            bool hasSliderAccuracy = !GetMods(Ruleset).OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
-            int sliderTailHits = beatmap.HitObjects.Count(x => x is Slider) - sliderTailMisses;
-
             return new Dictionary<HitResult, int>
             {
                 { HitResult.Great, countGreat },
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
                 { HitResult.LargeTickMiss, largeTickMisses },
-                { hasSliderAccuracy ? HitResult.SliderTailHit : HitResult.SmallTickHit, sliderTailHits },
+                { HitResult.SliderTailHit, beatmap.HitObjects.Count(x => x is Slider) - sliderTailMisses },
                 { HitResult.Miss, countMiss }
             };
         }

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -9,7 +9,6 @@ using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
-using osu.Game.Rulesets.Osu.Mods;
 using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 
@@ -36,11 +35,11 @@ namespace PerformanceCalculator.Simulate
 
         [UsedImplicitly]
         [Option(Template = "-L|--large-tick-misses <misses>", Description = "Number of large tick misses. Defaults to 0.")]
-        private int largeTickMisses { get; } = 0;
+        private int largeTickMisses { get; }
 
         [UsedImplicitly]
         [Option(Template = "-S|--slider-tail-misses <misses>", Description = "Number of slider tail misses. Defaults to 0.")]
-        private int sliderTailMisses { get; } = 0;
+        private int sliderTailMisses { get; }
 
         public override Ruleset Ruleset => new OsuRuleset();
 

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -3,11 +3,14 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using McMaster.Extensions.CommandLineUtils;
 using osu.Game.Beatmaps;
 using osu.Game.Rulesets;
 using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
 using osu.Game.Rulesets.Scoring;
 
 namespace PerformanceCalculator.Simulate
@@ -30,6 +33,14 @@ namespace PerformanceCalculator.Simulate
         [UsedImplicitly]
         [Option(Template = "-C|--percent-combo <combo>", Description = "Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.")]
         public override double PercentCombo { get; } = 100;
+
+        [UsedImplicitly]
+        [Option(Template = "-L|--large-tick-misses <misses>", Description = "Number of large tick misses. Defaults to 0.")]
+        private int largeTickMisses { get; } = 0;
+
+        [UsedImplicitly]
+        [Option(Template = "-S|--slider-tail-misses <misses>", Description = "Number of slider tail misses. Defaults to 0.")]
+        private int sliderTailMisses { get; } = 0;
 
         public override Ruleset Ruleset => new OsuRuleset();
 
@@ -111,11 +122,16 @@ namespace PerformanceCalculator.Simulate
                 countGreat = (int)(totalResultCount - countGood - countMeh - countMiss);
             }
 
+            bool hasSliderAccuracy = !GetMods(Ruleset).OfType<OsuModClassic>().All(m => m.NoSliderHeadAccuracy.Value);
+            int sliderTailHits = beatmap.HitObjects.Count(x => x is Slider) - sliderTailMisses;
+
             return new Dictionary<HitResult, int>
             {
                 { HitResult.Great, countGreat },
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
+                { HitResult.LargeTickMiss, largeTickMisses },
+                { hasSliderAccuracy ? HitResult.SliderTailHit : HitResult.SmallTickHit, sliderTailHits },
                 { HitResult.Miss, countMiss }
             };
         }


### PR DESCRIPTION
Depends on #223 

Adds `--large-tick-misses` and `--slider-tail-misses` parameters to the simulate command for the osu ruleset.

Contrary to the hit result being `SliderTailHit`, I decided to have the input be misses as this is the value that is also relevant for PP development.