### PR TITLE
Fix standard ruleset accuracy calculation on Lazer

### DIFF
--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -65,7 +65,7 @@ namespace PerformanceCalculator.Simulate
             };
         }
 
-        protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
+        protected override double GetAccuracy(IBeatmap beatmap, Dictionary<HitResult, int> statistics)
         {
             double hits = statistics[HitResult.Great] + statistics[HitResult.LargeTickHit] + statistics[HitResult.SmallTickHit];
             double total = hits + statistics[HitResult.Miss] + statistics[HitResult.SmallTickMiss];

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -130,15 +130,21 @@ namespace PerformanceCalculator.Simulate
             };
         }
 
-        protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
+        protected override double GetAccuracy(IBeatmap beatmap, Dictionary<HitResult, int> statistics)
         {
             var countGreat = statistics[HitResult.Great];
             var countGood = statistics[HitResult.Ok];
             var countMeh = statistics[HitResult.Meh];
             var countMiss = statistics[HitResult.Miss];
-            var total = countGreat + countGood + countMeh + countMiss;
 
-            return (double)((6 * countGreat) + (2 * countGood) + countMeh) / (6 * total);
+            var countSliders = beatmap.HitObjects.Count(x => x is Slider);
+            var countSliderTailHit = statistics[HitResult.SliderTailHit];
+            var countLargeTicks = beatmap.HitObjects.Sum(x => x.NestedHitObjects.Count(x => x is SliderTick or SliderRepeat));
+            var countLargeTickHit = countLargeTicks - statistics[HitResult.LargeTickMiss];
+
+            double total = 6 * (countGreat + countGood + countMeh + countMiss) + 3 * countSliders + 0.6 * countLargeTicks;
+
+            return (double)(6 * countGreat + 2 * countGood + countMeh + 3 * countSliderTailHit + 0.6 * countLargeTickHit) / total;
         }
     }
 }

--- a/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/OsuSimulateCommand.cs
@@ -139,12 +139,12 @@ namespace PerformanceCalculator.Simulate
 
             var countSliders = beatmap.HitObjects.Count(x => x is Slider);
             var countSliderTailHit = statistics[HitResult.SliderTailHit];
-            var countLargeTicks = beatmap.HitObjects.Sum(x => x.NestedHitObjects.Count(x => x is SliderTick or SliderRepeat));
+            var countLargeTicks = beatmap.HitObjects.Sum(obj => obj.NestedHitObjects.Count(x => x is SliderTick or SliderRepeat));
             var countLargeTickHit = countLargeTicks - statistics[HitResult.LargeTickMiss];
 
             double total = 6 * (countGreat + countGood + countMeh + countMiss) + 3 * countSliders + 0.6 * countLargeTicks;
 
-            return (double)(6 * countGreat + 2 * countGood + countMeh + 3 * countSliderTailHit + 0.6 * countLargeTickHit) / total;
+            return (6 * countGreat + 2 * countGood + countMeh + 3 * countSliderTailHit + 0.6 * countLargeTickHit) / total;
         }
     }
 }

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -69,7 +69,7 @@ namespace PerformanceCalculator.Simulate
             var statistics = GenerateHitResults(Accuracy / 100, beatmap, Misses, Mehs, Goods);
             var scoreInfo = new ScoreInfo(beatmap.BeatmapInfo, ruleset.RulesetInfo)
             {
-                Accuracy = GetAccuracy(statistics),
+                Accuracy = GetAccuracy(beatmap, statistics),
                 MaxCombo = Combo ?? (int)Math.Round(PercentCombo / 100 * beatmapMaxCombo),
                 Statistics = statistics,
                 Mods = mods
@@ -85,6 +85,6 @@ namespace PerformanceCalculator.Simulate
 
         protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood);
 
-        protected virtual double GetAccuracy(Dictionary<HitResult, int> statistics) => 0;
+        protected virtual double GetAccuracy(IBeatmap PlayableBeatmap, Dictionary<HitResult, int> statistics) => 0;
     }
 }

--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -85,6 +85,6 @@ namespace PerformanceCalculator.Simulate
 
         protected abstract Dictionary<HitResult, int> GenerateHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood);
 
-        protected virtual double GetAccuracy(IBeatmap PlayableBeatmap, Dictionary<HitResult, int> statistics) => 0;
+        protected virtual double GetAccuracy(IBeatmap beatmap, Dictionary<HitResult, int> statistics) => 0;
     }
 }

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -57,7 +57,7 @@ namespace PerformanceCalculator.Simulate
             };
         }
 
-        protected override double GetAccuracy(Dictionary<HitResult, int> statistics)
+        protected override double GetAccuracy(IBeatmap beatmap, Dictionary<HitResult, int> statistics)
         {
             var countGreat = statistics[HitResult.Great];
             var countGood = statistics[HitResult.Ok];


### PR DESCRIPTION
Resolves #226 

Adds large tick hits and slider tail hits to the accuracy calculation. For that, the `IBeatmap` is now passed into the `GetAccuracy` method, although unused on any ruleset except standard.