### PR TITLE
Fix accuracy formula being wrong for lazer scores in GUI

### DIFF
--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -21,7 +21,6 @@ using osu.Game.Rulesets.Taiko;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Skinning;
 using osu.Game.Utils;
-using osuTK;
 
 namespace PerformanceCalculatorGUI
 {

--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -21,6 +21,7 @@ using osu.Game.Rulesets.Taiko;
 using osu.Game.Rulesets.Taiko.Objects;
 using osu.Game.Skinning;
 using osu.Game.Utils;
+using osuTK;
 
 namespace PerformanceCalculatorGUI
 {
@@ -104,7 +105,7 @@ namespace PerformanceCalculatorGUI
             return (int)Math.Round(1000000 * scoreMultiplier);
         }
 
-        public static Dictionary<HitResult, int> GenerateHitResultsForRuleset(RulesetInfo ruleset, double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int countLargeTickMisses, int countSliderTailMisses)
+        public static Dictionary<HitResult, int> GenerateHitResultsForRuleset(RulesetInfo ruleset, double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int? countLargeTickMisses, int? countSliderTailMisses)
         {
             return ruleset.OnlineID switch
             {
@@ -116,7 +117,7 @@ namespace PerformanceCalculatorGUI
             };
         }
 
-        private static Dictionary<HitResult, int> generateOsuHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int countLargeTickMisses, int countSliderTailMisses)
+        private static Dictionary<HitResult, int> generateOsuHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countMeh, int? countGood, int? countLargeTickMisses, int? countSliderTailMisses)
         {
             int countGreat;
 
@@ -192,17 +193,21 @@ namespace PerformanceCalculatorGUI
                 countGreat = (int)(totalResultCount - countGood - countMeh - countMiss);
             }
 
-            int sliderTailHits = beatmap.HitObjects.Count(x => x is Slider) - countSliderTailMisses;
-
-            return new Dictionary<HitResult, int>
+            var result = new Dictionary<HitResult, int>
             {
                 { HitResult.Great, countGreat },
                 { HitResult.Ok, countGood ?? 0 },
                 { HitResult.Meh, countMeh ?? 0 },
-                { HitResult.LargeTickMiss, countLargeTickMisses },
-                { HitResult.SliderTailHit, sliderTailHits },
                 { HitResult.Miss, countMiss }
             };
+
+            if (countLargeTickMisses != null)
+                result[HitResult.LargeTickMiss] = countLargeTickMisses.Value;
+
+            if (countSliderTailMisses != null)
+                result[HitResult.SliderTailHit] = beatmap.HitObjects.Count(x => x is Slider) - countSliderTailMisses.Value;
+
+            return result;
         }
 
         private static Dictionary<HitResult, int> generateTaikoHitResults(double accuracy, IBeatmap beatmap, int countMiss, int? countGood)
@@ -293,11 +298,11 @@ namespace PerformanceCalculatorGUI
             };
         }
 
-        public static double GetAccuracyForRuleset(RulesetInfo ruleset, Dictionary<HitResult, int> statistics)
+        public static double GetAccuracyForRuleset(RulesetInfo ruleset, IBeatmap beatmap, Dictionary<HitResult, int> statistics)
         {
             return ruleset.OnlineID switch
             {
-                0 => getOsuAccuracy(statistics),
+                0 => getOsuAccuracy(beatmap, statistics),
                 1 => getTaikoAccuracy(statistics),
                 2 => getCatchAccuracy(statistics),
                 3 => getManiaAccuracy(statistics),
@@ -305,15 +310,35 @@ namespace PerformanceCalculatorGUI
             };
         }
 
-        private static double getOsuAccuracy(Dictionary<HitResult, int> statistics)
+        private static double getOsuAccuracy(IBeatmap beatmap, Dictionary<HitResult, int> statistics)
         {
             var countGreat = statistics[HitResult.Great];
             var countGood = statistics[HitResult.Ok];
             var countMeh = statistics[HitResult.Meh];
             var countMiss = statistics[HitResult.Miss];
-            var total = countGreat + countGood + countMeh + countMiss;
 
-            return (double)((6 * countGreat) + (2 * countGood) + countMeh) / (6 * total);
+            double total = 6 * countGreat + 2 * countGood + countMeh;
+            double max = 6 * (countGreat + countGood + countMeh + countMiss);
+
+            if (statistics.ContainsKey(HitResult.SliderTailHit))
+            {
+                var countSliders = beatmap.HitObjects.Count(x => x is Slider);
+                var countSliderTailHit = statistics[HitResult.SliderTailHit];
+
+                total += 3 * countSliderTailHit;
+                max += 3 * countSliders;
+            }
+
+            if (statistics.ContainsKey(HitResult.LargeTickMiss))
+            {
+                var countLargeTicks = beatmap.HitObjects.Sum(obj => obj.NestedHitObjects.Count(x => x is SliderTick or SliderRepeat));
+                var countLargeTickHit = countLargeTicks - statistics[HitResult.LargeTickMiss];
+
+                total += 0.6 * countLargeTickHit;
+                max += 0.6 * countLargeTicks;
+            }
+
+            return total / max;
         }
 
         private static double getTaikoAccuracy(Dictionary<HitResult, int> statistics)

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -702,10 +702,19 @@ namespace PerformanceCalculatorGUI.Screens
                 if (ruleset.Value.OnlineID != -1)
                 {
                     // official rulesets can generate more precise hits from accuracy
-                    statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood,
-                        largeTickMissesTextBox.Value.Value, sliderTailMissesTextBox.Value.Value);
+                    if (appliedMods.Value.OfType<OsuModClassic>().Any(m => m.NoSliderHeadAccuracy.Value))
+                    {
+                        statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood,
+                            null, null);
+                    }
+                    else
+                    {
+                        statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood,
+                            largeTickMissesTextBox.Value.Value, sliderTailMissesTextBox.Value.Value);
+                    }
+                        
 
-                    accuracy = RulesetHelper.GetAccuracyForRuleset(ruleset.Value, statistics);
+                    accuracy = RulesetHelper.GetAccuracyForRuleset(ruleset.Value, beatmap, statistics);
                 }
 
                 var ppAttributes = performanceCalculator?.Calculate(new ScoreInfo(beatmap.BeatmapInfo, ruleset.Value)

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -712,7 +712,6 @@ namespace PerformanceCalculatorGUI.Screens
                         statistics = RulesetHelper.GenerateHitResultsForRuleset(ruleset.Value, accuracyTextBox.Value.Value / 100.0, beatmap, missesTextBox.Value.Value, countMeh, countGood,
                             largeTickMissesTextBox.Value.Value, sliderTailMissesTextBox.Value.Value);
                     }
-                        
 
                     accuracy = RulesetHelper.GetAccuracyForRuleset(ruleset.Value, beatmap, statistics);
                 }


### PR DESCRIPTION
It used stable formula before.
Now it will use lazer formula automatically if lazer info is available.