### PR TITLE
Add documentation for passing large tick misses and slider tail misses arguments to osuSimulateCommand

### DIFF
--- a/PerformanceCalculator/README.md
+++ b/PerformanceCalculator/README.md
@@ -171,19 +171,21 @@ Computes the performance (pp) of a simulated osu! play.
 Usage: dotnet PerformanceCalculator.dll simulate osu <beatmap> [options]
 
 Arguments:
-  beatmap                     Required. Can be either a path to beatmap file (.osu) or beatmap ID.
+  beatmap                               Required. Can be either a path to beatmap file (.osu) or beatmap ID.
 
 Options:
-  -?|-h|--help                Show help information.
-  -a|--accuracy <accuracy>    Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well and is rounded to the nearest possible value for the beatmap.
-  -c|--combo <combo>          Maximum combo during play. Defaults to beatmap maximum.
-  -C|--percent-combo <combo>  Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.
-  -m|--mod <mod>              One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, ez, etc...
-  -X|--misses <misses>        Number of misses. Defaults to 0.
-  -M|--mehs <mehs>            Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.
-  -G|--goods <goods>          Number of goods. Will override accuracy if used. Otherwise is automatically calculated.
-  -j|--json                   Output results as JSON.
-  -o|--output <file.txt>      Output results to text file.
+  -?|-h|--help                        Show help information.
+  -a|--accuracy <accuracy>            Accuracy. Enter as decimal 0-100. Defaults to 100. Scales hit results as well and is rounded to the nearest possible value for the beatmap.
+  -c|--combo <combo>                  Maximum combo during play. Defaults to beatmap maximum.
+  -C|--percent-combo <combo>          Percentage of beatmap maximum combo achieved. Alternative to combo option. Enter as decimal 0-100.
+  -m|--mod <mod>                      One for each mod. The mods to compute the performance with. Values: hr, dt, hd, fl, ez, etc...
+  -L|--large-tick-misses <misses>"    Number of large tick misses. Defaults to 0.
+  -S|--slider-tail-misses <misses>"   Number of slider tail misses. Defaults to 0.
+  -X|--misses <misses>                Number of misses. Defaults to 0.
+  -M|--mehs <mehs>                    Number of mehs. Will override accuracy if used. Otherwise is automatically calculated.
+  -G|--goods <goods>                  Number of goods. Will override accuracy if used. Otherwise is automatically calculated.
+  -j|--json                           Output results as JSON.
+  -o|--output <file.txt>              Output results to text file.
 ```
 
 #### osu!taiko

--- a/PerformanceCalculator/README.md
+++ b/PerformanceCalculator/README.md
@@ -171,7 +171,7 @@ Computes the performance (pp) of a simulated osu! play.
 Usage: dotnet PerformanceCalculator.dll simulate osu <beatmap> [options]
 
 Arguments:
-  beatmap                               Required. Can be either a path to beatmap file (.osu) or beatmap ID.
+  beatmap                             Required. Can be either a path to beatmap file (.osu) or beatmap ID.
 
 Options:
   -?|-h|--help                        Show help information.


### PR DESCRIPTION
Hey! Just a little contribution on my part for the documentation. I hope it's okay!