### PR TITLE
Change profile score height to be smaller

### DIFF
--- a/PerformanceCalculatorGUI/Components/ExtendedProfileScore.cs
+++ b/PerformanceCalculatorGUI/Components/ExtendedProfileScore.cs
@@ -73,7 +73,7 @@ namespace PerformanceCalculatorGUI.Components
 
     public partial class ExtendedProfileScore : CompositeDrawable
     {
-        private const int height = 40;
+        private const int height = 35;
         private const int performance_width = 100;
         private const int rank_difference_width = 35;
         private const int small_text_font_size = 11;


### PR DESCRIPTION
This is a tiny change that makes a very big difference in usability, as seeing more scores without scrolling is a major improvement

**Before:**
![image](https://github.com/user-attachments/assets/cdf4039f-2266-44a3-8f8d-cdc1abead747)

**After:**
![image](https://github.com/user-attachments/assets/e3ea8136-d729-472a-ac3b-d699f3a7843b)
