### PR TITLE
Loop through colours to prevent crash in `StrainVisualizer`

### DIFF
--- a/PerformanceCalculatorGUI/Components/StrainVisualizer.cs
+++ b/PerformanceCalculatorGUI/Components/StrainVisualizer.cs
@@ -201,7 +201,7 @@ namespace PerformanceCalculatorGUI.Components
                         {
                             RelativeSizeAxes = Axes.Both,
                             MaxValue = strainMaxValue,
-                            Values = strainLists[i % skillColours.Length]
+                            Values = strainLists[i]
                         }
                     }
                 });

--- a/PerformanceCalculatorGUI/Components/StrainVisualizer.cs
+++ b/PerformanceCalculatorGUI/Components/StrainVisualizer.cs
@@ -111,7 +111,7 @@ namespace PerformanceCalculatorGUI.Components
                                 Width = 200,
                                 Current = { BindTarget = graphToggleBindable, Default = true, Value = true },
                                 LabelText = skills[i].GetType().Name,
-                                TextColour = skillColours[i]
+                                TextColour = skillColours[i % skillColours.Length]
                             }
                         }
                     });
@@ -196,12 +196,12 @@ namespace PerformanceCalculatorGUI.Components
                     {
                         RelativeSizeAxes = Axes.Both,
                         Alpha = graphAlpha,
-                        Colour = skillColours[i],
+                        Colour = skillColours[i % skillColours.Length],
                         Child = new StrainBarGraph
                         {
                             RelativeSizeAxes = Axes.Both,
                             MaxValue = strainMaxValue,
-                            Values = strainLists[i]
+                            Values = strainLists[i % skillColours.Length]
                         }
                     }
                 });


### PR DESCRIPTION
Currently StrainVisualizer causes a crash when trying to display more than six skills as only six colours are included. This prevents that crash by looping through the list of colours for skills past the sixth