### PR TITLE
Add beatmap stats tooltip, fix bpm not updating on mod settings changes

### DIFF
--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -582,6 +582,7 @@ namespace PerformanceCalculatorGUI.Screens
             // recreate calculators to update DHOs
             createCalculators();
 
+            modSettingChangeTracker?.Dispose();
             modSettingChangeTracker = new ModSettingChangeTracker(mods.NewValue);
             modSettingChangeTracker.SettingChanged += m =>
             {
@@ -592,7 +593,7 @@ namespace PerformanceCalculatorGUI.Screens
                     updateMissesTextboxes();
                     calculateDifficulty();
                     calculatePerformance();
-                }, 100);
+                }, 300);
             };
 
             calculateDifficulty();
@@ -647,6 +648,7 @@ namespace PerformanceCalculatorGUI.Screens
                 resetCalculations();
             }
 
+            beatmapTitle.Clear();
             beatmapTitle.Add(new BeatmapCard(working));
 
             loadBackground();


### PR DESCRIPTION
There's no way to see beatmap stats now after we got rid of them from diff attributes so this adds a tooltip when hovering over the beatmap card to bring that back. BPM was kept always visible as it is quite often required when adjusting rates

I've made HP and OD always visible assuming that those will be in all ruleset, similar to how difficulty adjust does it.

![image](https://github.com/user-attachments/assets/4fa4fad0-3884-4123-9ffd-59c0bae0442f)
