### PR TITLE
Replace manual attribute table building with an `AttributesTable` component

### DIFF
--- a/PerformanceCalculatorGUI/Components/TextBoxes/ReadonlyOsuTextBox.cs
+++ b/PerformanceCalculatorGUI/Components/TextBoxes/ReadonlyOsuTextBox.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Game.Graphics.UserInterface;
+
+namespace PerformanceCalculatorGUI.Components.TextBoxes
+{
+    public partial class ReadonlyOsuTextBox : OsuTextBox
+    {
+        private readonly string text;
+        private readonly bool hasBackground;
+
+        public ReadonlyOsuTextBox(string text, bool hasBackground = true)
+        {
+            this.text = text;
+            this.hasBackground = hasBackground;
+
+            Text = text;
+        }
+
+        protected override void LoadComplete()
+        {
+            if (!hasBackground)
+                BackgroundUnfocused = BackgroundUnfocused.Opacity(0);
+
+            base.LoadComplete();
+        }
+
+        protected override void OnUserTextAdded(string added)
+        {
+            NotifyInputError();
+            Text = text;
+        }
+
+        protected override void OnUserTextRemoved(string removed)
+        {
+            NotifyInputError();
+            Text = text;
+        }
+    }
+}

--- a/PerformanceCalculatorGUI/Screens/Simulate/AttributesTable.cs
+++ b/PerformanceCalculatorGUI/Screens/Simulate/AttributesTable.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Humanizer;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Overlays;
+using PerformanceCalculatorGUI.Components.TextBoxes;
+
+namespace PerformanceCalculatorGUI.Screens.Simulate
+{
+    public partial class AttributesTable : Container
+    {
+        public readonly Bindable<Dictionary<string, object>> Attributes = new Bindable<Dictionary<string, object>>();
+        private const float row_height = 35;
+
+        private FillFlowContainer backgroundFlow;
+        private GridContainer grid;
+
+        [Resolved]
+        private OverlayColourProvider colourProvider { get; set; }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            RelativeSizeAxes = Axes.X;
+            AutoSizeAxes = Axes.Y;
+
+            CornerRadius = ExtendedLabelledTextBox.CORNER_RADIUS;
+            Masking = true;
+
+            AddRangeInternal(new Drawable[]
+            {
+                backgroundFlow = new FillFlowContainer()
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical
+                },
+                grid = new GridContainer()
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    ColumnDimensions = new[] { new Dimension(GridSizeMode.AutoSize), new Dimension() }
+                }
+            });
+
+            Attributes.BindValueChanged(onAttributesChanged);
+        }
+
+        private void onAttributesChanged(ValueChangedEvent<Dictionary<string, object>> changedEvent)
+        {
+            grid.RowDimensions = Enumerable.Repeat(new Dimension(GridSizeMode.Absolute, row_height), changedEvent.NewValue.Count).ToArray();
+            grid.Content = changedEvent.NewValue.Select(s => createRowContent(s.Key, s.Value)).ToArray();
+
+            backgroundFlow.Children = changedEvent.NewValue.Select((_, i) => new Box
+            {
+                RelativeSizeAxes = Axes.X,
+                Height = row_height,
+                Colour = colourProvider.Background4.Opacity(i % 2 == 0 ? 0.7f : 0.9f),
+            }).ToArray();
+        }
+
+        private Drawable[] createRowContent(string label, object value) => new Drawable[]
+        {
+            new OsuSpriteText
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Font = OsuFont.GetFont(size: 16, weight: FontWeight.Bold),
+                Text = label.Humanize().ToLowerInvariant(),
+                Margin = new MarginPadding { Left = 15, Right = 10 },
+                UseFullGlyphHeight = true
+            },
+            new ReadonlyOsuTextBox(FormattableString.Invariant($"{value:N2}"), false)
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Height = 1,
+                RelativeSizeAxes = Axes.Both,
+                SelectAllOnFocus = true,
+                FontSize = 18,
+                CornerRadius = ExtendedLabelledTextBox.CORNER_RADIUS
+            },
+        }.ToArray();
+    }
+}

--- a/PerformanceCalculatorGUI/Screens/Simulate/AttributesTable.cs
+++ b/PerformanceCalculatorGUI/Screens/Simulate/AttributesTable.cs
@@ -40,13 +40,13 @@ namespace PerformanceCalculatorGUI.Screens.Simulate
 
             AddRangeInternal(new Drawable[]
             {
-                backgroundFlow = new FillFlowContainer()
+                backgroundFlow = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                     Direction = FillDirection.Vertical
                 },
-                grid = new GridContainer()
+                grid = new GridContainer
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Humanizer;
 using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -40,6 +39,7 @@ using PerformanceCalculatorGUI.Components;
 using PerformanceCalculatorGUI.Components.TextBoxes;
 using PerformanceCalculatorGUI.Configuration;
 using PerformanceCalculatorGUI.Screens.ObjectInspection;
+using PerformanceCalculatorGUI.Screens.Simulate;
 
 namespace PerformanceCalculatorGUI.Screens
 {
@@ -71,10 +71,10 @@ namespace PerformanceCalculatorGUI.Screens
         private SwitchButton fullScoreDataSwitch;
 
         private DifficultyAttributes difficultyAttributes;
-        private FillFlowContainer difficultyAttributesContainer;
-        private FillFlowContainer performanceAttributesContainer;
+        private AttributesTable difficultyAttributesContainer;
 
         private PerformanceCalculator performanceCalculator;
+        private AttributesTable performanceAttributesContainer;
 
         [Cached]
         private Bindable<DifficultyCalculator> difficultyCalculator = new Bindable<DifficultyCalculator>();
@@ -418,37 +418,23 @@ namespace PerformanceCalculatorGUI.Screens
                                             {
                                                 new OsuSpriteText
                                                 {
-                                                    Margin = new MarginPadding { Left = 10f, Top = 5f, Bottom = 10.0f },
+                                                    Margin = new MarginPadding { Left = 10f, Vertical = 5f },
                                                     Origin = Anchor.TopLeft,
                                                     Height = 20,
                                                     Text = "Difficulty Attributes"
                                                 },
-                                                difficultyAttributesContainer = new FillFlowContainer
-                                                {
-                                                    Direction = FillDirection.Vertical,
-                                                    RelativeSizeAxes = Axes.X,
-                                                    Anchor = Anchor.TopLeft,
-                                                    AutoSizeAxes = Axes.Y,
-                                                    Spacing = new Vector2(0, 2f)
-                                                },
+                                                difficultyAttributesContainer = new AttributesTable(),
                                                 new OsuSpriteText
                                                 {
-                                                    Margin = new MarginPadding(10.0f),
+                                                    Margin = new MarginPadding() { Left = 10f, Vertical = 5f },
                                                     Origin = Anchor.TopLeft,
                                                     Height = 20,
                                                     Text = "Performance Attributes"
                                                 },
-                                                performanceAttributesContainer = new FillFlowContainer
-                                                {
-                                                    Direction = FillDirection.Vertical,
-                                                    RelativeSizeAxes = Axes.X,
-                                                    Anchor = Anchor.TopLeft,
-                                                    AutoSizeAxes = Axes.Y,
-                                                    Spacing = new Vector2(0, 2f)
-                                                },
+                                                performanceAttributesContainer = new AttributesTable(),
                                                 new OsuSpriteText
                                                 {
-                                                    Margin = new MarginPadding(10.0f),
+                                                    Margin = new MarginPadding() { Left = 10f, Vertical = 5f },
                                                     Origin = Anchor.TopLeft,
                                                     Height = 20,
                                                     Text = "Strain graph (alt+scroll to zoom)"
@@ -674,14 +660,7 @@ namespace PerformanceCalculatorGUI.Screens
             try
             {
                 difficultyAttributes = difficultyCalculator.Value.Calculate(appliedMods.Value);
-                difficultyAttributesContainer.Children = AttributeConversion.ToDictionary(difficultyAttributes).Select(x =>
-                    new ExtendedLabelledTextBox
-                    {
-                        ReadOnly = true,
-                        Label = x.Key.Humanize().ToLowerInvariant(),
-                        Text = FormattableString.Invariant($"{x.Value:N2}")
-                    }
-                ).ToArray();
+                difficultyAttributesContainer.Attributes.Value = AttributeConversion.ToDictionary(difficultyAttributes);
             }
             catch (Exception e)
             {
@@ -757,14 +736,7 @@ namespace PerformanceCalculatorGUI.Screens
                     Ruleset = ruleset.Value
                 }, difficultyAttributes);
 
-                performanceAttributesContainer.Children = AttributeConversion.ToDictionary(ppAttributes).Select(x =>
-                    new ExtendedLabelledTextBox
-                    {
-                        ReadOnly = true,
-                        Label = x.Key.Humanize().ToLowerInvariant(),
-                        Text = FormattableString.Invariant($"{x.Value:N2}")
-                    }
-                ).ToArray();
+                performanceAttributesContainer.Attributes.Value = AttributeConversion.ToDictionary(ppAttributes);
             }
             catch (Exception e)
             {

--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -426,7 +426,7 @@ namespace PerformanceCalculatorGUI.Screens
                                                 difficultyAttributesContainer = new AttributesTable(),
                                                 new OsuSpriteText
                                                 {
-                                                    Margin = new MarginPadding() { Left = 10f, Vertical = 5f },
+                                                    Margin = new MarginPadding { Left = 10f, Vertical = 5f },
                                                     Origin = Anchor.TopLeft,
                                                     Height = 20,
                                                     Text = "Performance Attributes"
@@ -434,7 +434,7 @@ namespace PerformanceCalculatorGUI.Screens
                                                 performanceAttributesContainer = new AttributesTable(),
                                                 new OsuSpriteText
                                                 {
-                                                    Margin = new MarginPadding() { Left = 10f, Vertical = 5f },
+                                                    Margin = new MarginPadding { Left = 10f, Vertical = 5f },
                                                     Origin = Anchor.TopLeft,
                                                     Height = 20,
                                                     Text = "Strain graph (alt+scroll to zoom)"


### PR DESCRIPTION
`SimulateScreen` became insanely bloated over time, so it's time to start cutting it into components. This is the first one of hopefully many.

As a side-effect of this change you can now copy attribute values from the table and the table itself is more condensed which makes it easier to see all of it without scrolling

![image](https://github.com/user-attachments/assets/2f9efe4f-c65e-4953-8d62-a75da86ef53e)
