### PR TITLE
Fix `profile` command returning incorrect values

### DIFF
--- a/PerformanceCalculator/Profile/ProfileCommand.cs
+++ b/PerformanceCalculator/Profile/ProfileCommand.cs
@@ -45,16 +45,14 @@ namespace PerformanceCalculator.Profile
 
                 Mod[] mods = play.Mods.Select(x => x.ToMod(ruleset)).ToArray();
 
-                var scoreInfo = play.ToScoreInfo(mods);
+                var scoreInfo = play.ToScoreInfo(mods, working.BeatmapInfo);
                 scoreInfo.Ruleset = ruleset.RulesetInfo;
-
-                var score = new ProcessorScoreDecoder(working).Parse(scoreInfo);
 
                 var difficultyCalculator = ruleset.CreateDifficultyCalculator(working);
                 var difficultyAttributes = difficultyCalculator.Calculate(scoreInfo.Mods);
                 var performanceCalculator = ruleset.CreatePerformanceCalculator();
 
-                var ppAttributes = performanceCalculator?.Calculate(score.ScoreInfo, difficultyAttributes);
+                var ppAttributes = performanceCalculator?.Calculate(scoreInfo, difficultyAttributes);
                 var thisPlay = new UserPlayInfo
                 {
                     Beatmap = working.BeatmapInfo,


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/fce177d9-a70d-4d20-b66f-2df0ee825da8)

after:
![image](https://github.com/user-attachments/assets/cb01571a-cd17-4a3e-9380-0177df364fe6)
