### PR TITLE
Add option to pass legacy total score to CLI

### DIFF
--- a/PerformanceCalculator/Simulate/SimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/SimulateCommand.cs
@@ -40,6 +40,10 @@ namespace PerformanceCalculator.Simulate
         [Option(Template = "-X|--misses <misses>", Description = "Number of misses. Defaults to 0.")]
         public int Misses { get; }
 
+        [UsedImplicitly]
+        [Option(Template = "-l|--legacy-total-score <score>", Description = "Amount of legacy total score.")]
+        public long? LegacyTotalScore { get; }
+
         //
         // Options implemented in the ruleset-specific commands
         // -> Catch renames Mehs/Goods to (tiny-)droplets
@@ -73,6 +77,7 @@ namespace PerformanceCalculator.Simulate
                 Accuracy = GetAccuracy(beatmap, statistics),
                 MaxCombo = Combo ?? (int)Math.Round(PercentCombo / 100 * beatmapMaxCombo),
                 Statistics = statistics,
+                LegacyTotalScore = LegacyTotalScore,
                 Mods = mods
             };
 


### PR DESCRIPTION
Creating this to be able to test my new algorithm for scorev1-based effective misscount via different tools like Huis and Sheet generator.