### PR TITLE
Use `LegacyTotalScore` if set when parsing `ScoreInfo`

### DIFF
--- a/PerformanceCalculatorGUI/ProcessorScoreDecoder.cs
+++ b/PerformanceCalculatorGUI/ProcessorScoreDecoder.cs
@@ -24,7 +24,7 @@ namespace PerformanceCalculatorGUI
         public Score Parse(ScoreInfo scoreInfo)
         {
             var score = new Score { ScoreInfo = scoreInfo };
-            score.ScoreInfo.LegacyTotalScore = score.ScoreInfo.TotalScore;
+            score.ScoreInfo.LegacyTotalScore ??= score.ScoreInfo.TotalScore;
             PopulateMaximumStatistics(score.ScoreInfo, beatmap);
             StandardisedScoreMigrationTools.UpdateFromLegacy(score.ScoreInfo, beatmap);
             return score;


### PR DESCRIPTION
Noticed when trying https://github.com/ppy/osu/pull/33066. Currently, this is going down the path of estimating legacy score for stable scores and was causing differing values.