### PR TITLE
Show correct object difficulty values with rate-adjusting mods

### DIFF
--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/CatchObjectInspectorRuleset.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/CatchObjectInspectorRuleset.cs
@@ -35,7 +35,7 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
         protected override void Update()
         {
             base.Update();
-            objectDifficultyValuesContainer.CurrentDifficultyHitObject.Value = difficultyHitObjects.LastOrDefault(x => x.StartTime <= Clock.CurrentTime);
+            objectDifficultyValuesContainer.CurrentDifficultyHitObject.Value = difficultyHitObjects.LastOrDefault(x => x.BaseObject.StartTime <= Clock.CurrentTime);
         }
     }
 }

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/OsuObjectInspectorRuleset.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/OsuObjectInspectorRuleset.cs
@@ -34,7 +34,7 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
         protected override void Update()
         {
             base.Update();
-            objectDifficultyValuesContainer.CurrentDifficultyHitObject.Value = difficultyHitObjects.LastOrDefault(x => x.StartTime <= Clock.CurrentTime);
+            objectDifficultyValuesContainer.CurrentDifficultyHitObject.Value = difficultyHitObjects.LastOrDefault(x => x.BaseObject.StartTime <= Clock.CurrentTime);
         }
 
         public override bool PropagatePositionalInputSubTree => false;

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/TaikoObjectInspectorRuleset.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/TaikoObjectInspectorRuleset.cs
@@ -41,7 +41,7 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
         protected override void Update()
         {
             base.Update();
-            objectDifficultyValuesContainer.CurrentDifficultyHitObject.Value = difficultyHitObjects.LastOrDefault(x => x.StartTime <= Clock.CurrentTime);
+            objectDifficultyValuesContainer.CurrentDifficultyHitObject.Value = difficultyHitObjects.LastOrDefault(x => x.BaseObject.StartTime <= Clock.CurrentTime);
         }
 
         private partial class TaikoObjectInspectorPlayfield : TaikoPlayfield


### PR DESCRIPTION
Currently, the object inspector shows incorrect difficulty values with rate-adjusting mods. The clock runs at base speed while difficulty hit objects have their start times adjusted by mods. This leads to the inspector showing values of a different hit object, not the current one.
`DifficultyHitObject.BaseObject.StartTime` isn't adjusted by mods so let's use it for comparison against the clock's time.