### PR TITLE
Fix crash when CL is being disabled

### DIFF
--- a/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
+++ b/PerformanceCalculatorGUI/Screens/SimulateScreen.cs
@@ -875,6 +875,7 @@ namespace PerformanceCalculatorGUI.Screens
             // It can only be triggered by a couple of input events and there's no way to invalidate it from the outside
             // See: https://github.com/ppy/osu-framework/blob/fd5615732033c5ea650aa5cabc8595883a2b63f5/osu.Framework/Graphics/UserInterface/TextBox.cs#L528
             if (textbox.Parent == null) return;
+
             textbox.TriggerEvent(new FocusEvent(new InputState(), this));
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu-tools/issues/253.
I personally don't think that `fixupTextPox` function is needed in the first place, but this will at least fix the crash.