### PR TITLE
Allow easy access to all osu!catch difficulty hit objects in the object inspector

### DIFF
--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/ObjectInspector.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/ObjectInspector.cs
@@ -15,10 +15,13 @@ using osu.Game.Graphics.Containers;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
 using osu.Game.Rulesets;
+using osu.Game.Rulesets.Catch.Beatmaps;
+using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Catch.UI;
 using osu.Game.Rulesets.Difficulty;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Osu.UI;
 using osu.Game.Rulesets.Taiko.UI;
 using osu.Game.Rulesets.UI;
@@ -61,6 +64,7 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
         private ObjectDifficultyValuesContainer difficultyValuesContainer;
         private IBeatmap playableBeatmap;
         private EditorBeatmap editorBeatmap;
+        private IReadOnlyList<HitObject> hitObjects;
 
         protected override bool BlockNonPositionalInput => true;
 
@@ -94,6 +98,12 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
             dependencies.CacheAs(editorBeatmap);
 
             beatmap.Value = processorBeatmap;
+
+            hitObjects = ruleset.Value.ShortName switch
+            {
+                "fruits" => CatchBeatmap.GetPalpableObjects(playableBeatmap.HitObjects).Where(o => o is not (Banana or TinyDroplet)).ToList(),
+                _ => playableBeatmap.HitObjects,
+            };
 
             Timeline timeline;
 
@@ -277,9 +287,9 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
 
             if (e.Key == Key.Left)
             {
-                seekTo = playableBeatmap.HitObjects
-                                        .LastOrDefault(x => x.StartTime < clock.CurrentTime)?
-                                        .StartTime;
+                seekTo = hitObjects
+                         .LastOrDefault(x => x.StartTime < clock.CurrentTime)?
+                         .StartTime;
 
                 // slight leeway to make going back beyond just one object possible when the clock is running
                 if (clock.IsRunning)
@@ -288,9 +298,9 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
 
             if (e.Key == Key.Right)
             {
-                seekTo = playableBeatmap.HitObjects
-                                        .FirstOrDefault(x => x.StartTime > clock.CurrentTime)?
-                                        .StartTime;
+                seekTo = hitObjects
+                         .FirstOrDefault(x => x.StartTime > clock.CurrentTime)?
+                         .StartTime;
             }
 
             if (seekTo != null)

--- a/PerformanceCalculatorGUI/Screens/ObjectInspection/TimelineBlueprintContainer.cs
+++ b/PerformanceCalculatorGUI/Screens/ObjectInspection/TimelineBlueprintContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
@@ -12,6 +13,7 @@ using osu.Framework.Utils;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Sprites;
 using osu.Game.Overlays;
+using osu.Game.Rulesets.Catch.Objects;
 using osu.Game.Rulesets.Edit;
 using osu.Game.Rulesets.Objects;
 using osu.Game.Rulesets.Objects.Types;
@@ -42,7 +44,22 @@ namespace PerformanceCalculatorGUI.Screens.ObjectInspection
             base.LoadComplete();
 
             foreach (var obj in Beatmap.HitObjects)
-                AddBlueprintFor(obj);
+            {
+                switch (obj)
+                {
+                    case BananaShower:
+                        continue;
+
+                    case JuiceStream:
+                        foreach (var nestedObj in obj.NestedHitObjects.Where(o => o is not TinyDroplet))
+                            AddBlueprintFor(nestedObj);
+                        break;
+
+                    default:
+                        AddBlueprintFor(obj);
+                        break;
+                }
+            }
         }
 
         protected override SelectionBlueprintContainer CreateSelectionBlueprintContainer() => new TimelineSelectionBlueprintContainer { RelativeSizeAxes = Axes.Both };


### PR DESCRIPTION
Currently the timeline only shows circles, slider starts, and spinners. In osu!catch, slider ticks and slider ends (converted to large droplets and fruits respectively) have difficulty hit objects as well, but it's problematic to see the values since the arrow keys skip them. This PR addresses that. Other modes have no changes.
I set banana showers to be skipped because there are no difficulty hit objects for them.
I haven't touched the look of objects on the timeline, I don't know whether the slider ticks/ends should be shown differently.

Before:
<img width="1826" height="846" alt="image" src="https://github.com/user-attachments/assets/33740732-0904-49bd-afc7-e947004c8ea8" />

After:
<img width="1826" height="846" alt="image" src="https://github.com/user-attachments/assets/6fccdbd6-f67e-4b27-87e3-cf0a570b23c1" />