### PR TITLE
Change toolbar buttons tooltips to be more visible

### DIFF
--- a/PerformanceCalculatorGUI/Components/ScreenSelectionButton.cs
+++ b/PerformanceCalculatorGUI/Components/ScreenSelectionButton.cs
@@ -25,9 +25,9 @@ namespace PerformanceCalculatorGUI.Components
         private readonly string title;
         private readonly GlobalAction? hotkey;
 
-        public const float PADDING = 3;
+        private const float padding = 3;
 
-        protected Box HoverBackground;
+        private Box hoverBackground;
         private readonly Box flashBackground;
 
         public ScreenSelectionButton(string title, IconUsage? icon = null, GlobalAction? hotkey = null)
@@ -44,7 +44,7 @@ namespace PerformanceCalculatorGUI.Components
                 {
                     Width = PerformanceCalculatorSceneManager.CONTROL_AREA_HEIGHT,
                     RelativeSizeAxes = Axes.Y,
-                    Padding = new MarginPadding(PADDING),
+                    Padding = new MarginPadding(padding),
                     Children = new Drawable[]
                     {
                         new Container
@@ -55,20 +55,20 @@ namespace PerformanceCalculatorGUI.Components
                             CornerExponent = 3f,
                             Children = new Drawable[]
                             {
-                                HoverBackground = new Box
+                                hoverBackground = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     Colour = OsuColour.Gray(80).Opacity(180),
                                     Blending = BlendingParameters.Additive,
-                                    Alpha = 0,
+                                    Alpha = 0
                                 },
                                 flashBackground = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     Alpha = 0,
                                     Colour = Color4.White.Opacity(100),
-                                    Blending = BlendingParameters.Additive,
-                                },
+                                    Blending = BlendingParameters.Additive
+                                }
                             }
                         },
                         new FillFlowContainer
@@ -87,11 +87,11 @@ namespace PerformanceCalculatorGUI.Components
                                     Origin = Anchor.CentreLeft,
                                     Size = new Vector2(25),
                                     Icon = new ScreenSelectionButtonIcon(icon) { IconSize = new Vector2(20) }
-                                },
-                            },
-                        },
-                    },
-                },
+                                }
+                            }
+                        }
+                    }
+                }
             };
         }
 
@@ -105,13 +105,13 @@ namespace PerformanceCalculatorGUI.Components
 
         protected override bool OnHover(HoverEvent e)
         {
-            HoverBackground.FadeIn(300, Easing.OutQuint);
+            hoverBackground.FadeIn(300, Easing.OutQuint);
             return true;
         }
 
         protected override void OnHoverLost(HoverLostEvent e)
         {
-            HoverBackground.FadeOut(200, Easing.Out);
+            hoverBackground.FadeOut(200, Easing.Out);
         }
 
         public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
@@ -140,8 +140,8 @@ namespace PerformanceCalculatorGUI.Components
         {
             private (string, GlobalAction?)? currentData;
 
-            private FillFlowContainer subTooltipFlow;
-            private OsuSpriteText text;
+            private readonly FillFlowContainer subTooltipFlow;
+            private readonly OsuSpriteText text;
 
             public ScreenSelectionButtonTooltip()
             {
@@ -153,7 +153,7 @@ namespace PerformanceCalculatorGUI.Components
                 {
                     Type = EdgeEffectType.Shadow,
                     Colour = Color4.Black.Opacity(0.2f),
-                    Radius = 10f,
+                    Radius = 10f
                 };
 
                 Children = new Drawable[]
@@ -161,7 +161,7 @@ namespace PerformanceCalculatorGUI.Components
                     new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Colour = OsuColour.Gray(0.1f),
+                        Colour = OsuColour.Gray(0.1f)
                     },
                     new FillFlowContainer
                     {
@@ -176,14 +176,14 @@ namespace PerformanceCalculatorGUI.Components
                                 Anchor = Anchor.TopLeft,
                                 Origin = Anchor.TopLeft,
                                 Shadow = true,
-                                Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold),
+                                Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold)
                             },
                             subTooltipFlow = new FillFlowContainer
                             {
                                 AutoSizeAxes = Axes.Both,
                                 Anchor = Anchor.TopLeft,
                                 Origin = Anchor.TopLeft,
-                                Direction = FillDirection.Horizontal,
+                                Direction = FillDirection.Horizontal
                             }
                         }
                     }
@@ -210,7 +210,7 @@ namespace PerformanceCalculatorGUI.Components
                         Anchor = Anchor.BottomLeft,
                         Origin = Anchor.BottomLeft,
                         Hotkey = new Hotkey(data.Item2.Value),
-                        Margin = new MarginPadding { Left = 3 },
+                        Margin = new MarginPadding { Left = 3 }
                     });
                 }
             }

--- a/PerformanceCalculatorGUI/Components/ScreenSelectionButton.cs
+++ b/PerformanceCalculatorGUI/Components/ScreenSelectionButton.cs
@@ -27,7 +27,7 @@ namespace PerformanceCalculatorGUI.Components
 
         private const float padding = 3;
 
-        private Box hoverBackground;
+        private readonly Box hoverBackground;
         private readonly Box flashBackground;
 
         public ScreenSelectionButton(string title, IconUsage? icon = null, GlobalAction? hotkey = null)

--- a/PerformanceCalculatorGUI/Components/ScreenSelectionButton.cs
+++ b/PerformanceCalculatorGUI/Components/ScreenSelectionButton.cs
@@ -1,21 +1,221 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.Events;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Containers;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterface;
 using osu.Game.Input.Bindings;
-using osu.Game.Overlays.Toolbar;
 using osuTK;
+using osuTK.Graphics;
 
 namespace PerformanceCalculatorGUI.Components
 {
-    public partial class ScreenSelectionButton : ToolbarButton
+    public partial class ScreenSelectionButton : OsuClickableContainer, IKeyBindingHandler<GlobalAction>, IHasCustomTooltip<(string, GlobalAction?)>
     {
+        private readonly string title;
+        private readonly GlobalAction? hotkey;
+
+        public const float PADDING = 3;
+
+        protected Box HoverBackground;
+        private readonly Box flashBackground;
+
         public ScreenSelectionButton(string title, IconUsage? icon = null, GlobalAction? hotkey = null)
         {
-            Hotkey = hotkey;
-            TooltipMain = title;
+            this.title = title;
+            this.hotkey = hotkey;
 
-            SetIcon(new ScreenSelectionButtonIcon(icon) { IconSize = new Vector2(25) });
+            AutoSizeAxes = Axes.X;
+            RelativeSizeAxes = Axes.Y;
+
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    Width = PerformanceCalculatorSceneManager.CONTROL_AREA_HEIGHT,
+                    RelativeSizeAxes = Axes.Y,
+                    Padding = new MarginPadding(PADDING),
+                    Children = new Drawable[]
+                    {
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            CornerRadius = 6,
+                            CornerExponent = 3f,
+                            Children = new Drawable[]
+                            {
+                                HoverBackground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = OsuColour.Gray(80).Opacity(180),
+                                    Blending = BlendingParameters.Additive,
+                                    Alpha = 0,
+                                },
+                                flashBackground = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    Colour = Color4.White.Opacity(100),
+                                    Blending = BlendingParameters.Additive,
+                                },
+                            }
+                        },
+                        new FillFlowContainer
+                        {
+                            Direction = FillDirection.Horizontal,
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Padding = new MarginPadding { Horizontal = PerformanceCalculatorSceneManager.CONTROL_AREA_HEIGHT / 2 },
+                            RelativeSizeAxes = Axes.Y,
+                            AutoSizeAxes = Axes.X,
+                            Children = new Drawable[]
+                            {
+                                new ConstrainedIconContainer
+                                {
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Size = new Vector2(25),
+                                    Icon = new ScreenSelectionButtonIcon(icon) { IconSize = new Vector2(20) }
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+        }
+
+        protected override bool OnMouseDown(MouseDownEvent e) => false;
+
+        protected override bool OnClick(ClickEvent e)
+        {
+            flashBackground.FadeIn(50).Then().FadeOutFromOne(800, Easing.OutQuint);
+            return base.OnClick(e);
+        }
+
+        protected override bool OnHover(HoverEvent e)
+        {
+            HoverBackground.FadeIn(300, Easing.OutQuint);
+            return true;
+        }
+
+        protected override void OnHoverLost(HoverLostEvent e)
+        {
+            HoverBackground.FadeOut(200, Easing.Out);
+        }
+
+        public bool OnPressed(KeyBindingPressEvent<GlobalAction> e)
+        {
+            if (e.Action == hotkey && !e.Repeat)
+            {
+                TriggerClick();
+                return true;
+            }
+
+            return false;
+        }
+
+        public void OnReleased(KeyBindingReleaseEvent<GlobalAction> e)
+        {
+        }
+
+        public ITooltip<(string, GlobalAction?)> GetCustomTooltip()
+        {
+            return new ScreenSelectionButtonTooltip();
+        }
+
+        public (string, GlobalAction?) TooltipContent => (title, hotkey);
+
+        public partial class ScreenSelectionButtonTooltip : VisibilityContainer, ITooltip<(string, GlobalAction?)>
+        {
+            private (string, GlobalAction?)? currentData;
+
+            private FillFlowContainer subTooltipFlow;
+            private OsuSpriteText text;
+
+            public ScreenSelectionButtonTooltip()
+            {
+                AutoSizeAxes = Axes.Both;
+                Masking = true;
+                CornerRadius = 5;
+
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Type = EdgeEffectType.Shadow,
+                    Colour = Color4.Black.Opacity(0.2f),
+                    Radius = 10f,
+                };
+
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = OsuColour.Gray(0.1f),
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Padding = new MarginPadding(8f),
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(5),
+                        Children = new Drawable[]
+                        {
+                            text = new OsuSpriteText
+                            {
+                                Anchor = Anchor.TopLeft,
+                                Origin = Anchor.TopLeft,
+                                Shadow = true,
+                                Font = OsuFont.GetFont(size: 18, weight: FontWeight.Bold),
+                            },
+                            subTooltipFlow = new FillFlowContainer
+                            {
+                                AutoSizeAxes = Axes.Both,
+                                Anchor = Anchor.TopLeft,
+                                Origin = Anchor.TopLeft,
+                                Direction = FillDirection.Horizontal,
+                            }
+                        }
+                    }
+                };
+            }
+
+            protected override void PopIn() => this.FadeIn(300, Easing.OutQuint);
+            protected override void PopOut() => this.FadeOut(200, Easing.Out);
+
+            public void SetContent((string, GlobalAction?) data)
+            {
+                if (currentData == data)
+                    return;
+
+                currentData = data;
+                subTooltipFlow.Clear();
+
+                text.Text = data.Item1;
+
+                if (data.Item2 != null)
+                {
+                    subTooltipFlow.Add(new HotkeyDisplay
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.BottomLeft,
+                        Hotkey = new Hotkey(data.Item2.Value),
+                        Margin = new MarginPadding { Left = 3 },
+                    });
+                }
+            }
+
+            public void Move(Vector2 pos) => Position = pos;
         }
     }
 }

--- a/PerformanceCalculatorGUI/Components/SettingsButton.cs
+++ b/PerformanceCalculatorGUI/Components/SettingsButton.cs
@@ -2,27 +2,19 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Extensions;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Game.Input.Bindings;
-using osu.Game.Overlays.Toolbar;
-using osuTK;
 
 namespace PerformanceCalculatorGUI.Components
 {
-    public partial class SettingsButton : ToolbarButton, IHasPopover
+    public partial class SettingsButton : ScreenSelectionButton, IHasPopover
     {
-        protected override Anchor TooltipAnchor => Anchor.TopRight;
-
         public SettingsButton()
+            : base("Settings", FontAwesome.Solid.Cog, GlobalAction.ToggleSettings)
         {
-            Hotkey = GlobalAction.ToggleSettings;
-            TooltipMain = "Settings";
-
-            SetIcon(new ScreenSelectionButtonIcon(FontAwesome.Solid.Cog) { IconSize = new Vector2(70) });
         }
 
         public Popover GetPopover() => new SettingsPopover();

--- a/PerformanceCalculatorGUI/PerformanceCalculatorSceneManager.cs
+++ b/PerformanceCalculatorGUI/PerformanceCalculatorSceneManager.cs
@@ -3,15 +3,12 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Screens;
-using osu.Game.Beatmaps.Drawables.Cards;
 using osu.Game.Configuration;
 using osu.Game.Graphics;
 using osu.Game.Graphics.Containers;
@@ -19,8 +16,6 @@ using osu.Game.Overlays;
 using osu.Game.Overlays.Dialog;
 using osu.Game.Overlays.Toolbar;
 using osu.Game.Rulesets;
-using osuTK;
-using osuTK.Graphics;
 using PerformanceCalculatorGUI.Components;
 using PerformanceCalculatorGUI.Screens;
 
@@ -32,8 +27,6 @@ namespace PerformanceCalculatorGUI
         private ScreenStack screenStack = null!;
 
         private ToolbarRulesetSelector rulesetSelector = null!;
-
-        private Box hoverGradientBox = null!;
 
         public const float CONTROL_AREA_HEIGHT = 45;
 
@@ -68,19 +61,10 @@ namespace PerformanceCalculatorGUI
                         {
                             new Drawable[]
                             {
-                                new HoverHandlingContainer
+                                new Container
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     Height = CONTROL_AREA_HEIGHT,
-                                    Hovered = e =>
-                                    {
-                                        hoverGradientBox.FadeIn(100);
-                                        return false;
-                                    },
-                                    Unhovered = e =>
-                                    {
-                                        hoverGradientBox.FadeOut(100);
-                                    },
                                     Children = new Drawable[]
                                     {
                                         new Box
@@ -124,7 +108,6 @@ namespace PerformanceCalculatorGUI
                                             Direction = FillDirection.Horizontal,
                                             RelativeSizeAxes = Axes.Y,
                                             AutoSizeAxes = Axes.X,
-                                            Spacing = new Vector2(5),
                                             Children = new Drawable[]
                                             {
                                                 rulesetSelector = new ToolbarRulesetSelector(),
@@ -138,21 +121,10 @@ namespace PerformanceCalculatorGUI
                             {
                                 new ScalingContainer(ScalingMode.Everything)
                                 {
-                                    Depth = 1,
-                                    Children = new Drawable[]
+                                    Child = screenStack = new ScreenStack
                                     {
-                                        screenStack = new ScreenStack
-                                        {
-                                            RelativeSizeAxes = Axes.Both
-                                        },
-                                        hoverGradientBox = new Box
-                                        {
-                                            Colour = ColourInfo.GradientVertical(Color4.Black.Opacity(1.0f), Color4.Black.Opacity(1)),
-                                            RelativeSizeAxes = Axes.X,
-                                            Height = 100,
-                                            Alpha = 0
-                                        }
-                                    }
+                                        RelativeSizeAxes = Axes.Both
+                                    },
                                 }
                             }
                         }


### PR DESCRIPTION
Before:
<img width="329" height="162" alt="image" src="https://github.com/user-attachments/assets/76120be2-156e-4a78-8efd-1af78efef9ba" />
After:
<img width="345" height="184" alt="image" src="https://github.com/user-attachments/assets/d8d5a9fe-1fd3-4edc-9f3c-083cba157720" />

Hover container in the `PerformanceCalculatorSceneManager` never really worked which made the buttons tooltip text annoying to read. This changes it to be based on normal tooltips logic instead
`ScreenSelectionButton` is now a slimmed down copy of the `ToolbarButton` now