### PR TITLE
Fix taiko hit result generation when only misses are provided

### DIFF
--- a/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/CatchSimulateCommand.cs
@@ -51,9 +51,9 @@ namespace PerformanceCalculator.Simulate
             // Max value minus whatever misses are left. Negative if impossible missCount
             int countFruits = maxFruits - (countMiss - (maxDroplets - countDroplets));
 
-            // Either given or the max amount of hit objects with respect to accuracy minus the already calculated fruits and drops.
-            // Negative if accuracy not feasable with missCount.
-            int countTinyDroplets = countMeh ?? (int)Math.Round(accuracy * (maxCombo + maxTinyDroplets)) - countFruits - countDroplets;
+            // Either given or the max amount of "hit" hit objects with respect to accuracy minus the already calculated fruits and drops.
+            int relevantResultCount = maxCombo + maxTinyDroplets - countMiss;
+            int countTinyDroplets = countMeh ?? (int)Math.Round(accuracy * relevantResultCount) - countFruits - countDroplets;
 
             // Whatever droplets are left
             int countTinyMisses = maxTinyDroplets - countTinyDroplets;

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -45,8 +45,8 @@ namespace PerformanceCalculator.Simulate
             else
             {
                 // Let Great=2, Good=1, Miss=0. The total should be this.
-                int hitCount = totalResultCount - countMiss;
-                int targetTotal = (int)Math.Round(accuracy * hitCount * 2);
+                int relevantResultCount = totalResultCount - countMiss;
+                int targetTotal = (int)Math.Round(accuracy * relevantResultCount * 2);
 
                 countGreat = targetTotal - (totalResultCount - countMiss);
                 countGood = totalResultCount - countGreat - countMiss;

--- a/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
+++ b/PerformanceCalculator/Simulate/TaikoSimulateCommand.cs
@@ -45,7 +45,8 @@ namespace PerformanceCalculator.Simulate
             else
             {
                 // Let Great=2, Good=1, Miss=0. The total should be this.
-                int targetTotal = (int)Math.Round(accuracy * totalResultCount * 2);
+                int hitCount = totalResultCount - countMiss;
+                int targetTotal = (int)Math.Round(accuracy * hitCount * 2);
 
                 countGreat = targetTotal - (totalResultCount - countMiss);
                 countGood = totalResultCount - countGreat - countMiss;

--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -204,9 +204,9 @@ namespace PerformanceCalculatorGUI
             // Max value minus whatever misses are left. Negative if impossible missCount
             int countFruits = maxFruits - (countMiss - (maxDroplets - countDroplets));
 
-            // Either given or the max amount of hit objects with respect to accuracy minus the already calculated fruits and drops.
-            // Negative if accuracy not feasable with missCount.
-            int countTinyDroplets = countMeh ?? (int)Math.Round(accuracy * (maxCombo + maxTinyDroplets)) - countFruits - countDroplets;
+            // Either given or the max amount of "hit" hit objects with respect to accuracy minus the already calculated fruits and drops.
+            int relevantResultCount = maxCombo + maxTinyDroplets - countMiss;
+            int countTinyDroplets = countMeh ?? (int)Math.Round(accuracy * relevantResultCount) - countFruits - countDroplets;
 
             // Whatever droplets are left
             int countTinyMisses = maxTinyDroplets - countTinyDroplets;

--- a/PerformanceCalculatorGUI/RulesetHelper.cs
+++ b/PerformanceCalculatorGUI/RulesetHelper.cs
@@ -174,7 +174,8 @@ namespace PerformanceCalculatorGUI
             else
             {
                 // Let Great=2, Good=1, Miss=0. The total should be this.
-                int targetTotal = (int)Math.Round(accuracy * totalResultCount * 2);
+                int relevantResultCount = totalResultCount - countMiss;
+                int targetTotal = (int)Math.Round(accuracy * relevantResultCount * 2);
 
                 countGreat = targetTotal - (totalResultCount - countMiss);
                 countGood = totalResultCount - countGreat - countMiss;


### PR DESCRIPTION
I ran across this issue when trying to simulate a taiko score with just missing combo and misses, but no goods or accuracy specified.

Example: `dotnet run -- simulate taiko 132889 --combo 758 --misses 11`

This causes performance calculation to throw, due to a `NaN` caused by a greats count higher (958) than possible and a goods count in the negative (-22).

The issue here is that it tries to calculate the greats/goods count from a `targetTotal`, which is calculated via `accuracy` and `totalResultCount`:
```cs
int hitCount = totalResultCount - countMiss;
int targetTotal = (int)Math.Round(accuracy * hitCount * 2);

countGreat = targetTotal - (totalResultCount - countMiss);
countGood = totalResultCount - countGreat - countMiss;
```
If an `accuracy` of `1` is passed, along with a `countMiss` of `11`, it assumes the accuracy includes the misses. This is incorrect behavior, and instead it should be `accuracy * (totalResultCount - countMiss) * 2`.

The idea that `accuracy` refers to the hit portion of the hit results is also seen in the [`generateHitResults` method of the osu-ruleset](https://github.com/ppy/osu-tools/blob/master/PerformanceCalculator/Simulate/OsuSimulateCommand.cs#L74).